### PR TITLE
ART-1112: Add new modification action `add`

### DIFF
--- a/tests/test_schema/test_modification_schema.py
+++ b/tests/test_schema/test_modification_schema.py
@@ -1,0 +1,21 @@
+import unittest
+import schema
+from validator.schema.modification_schema import modification
+
+
+class TestModificationSchema(unittest.TestCase):
+    def test_modification_with_valid_data(self):
+        input = {
+            "action": "add",
+            "source": "https://example.org/some-path/gating.yaml",
+            "path": "gating.yaml",
+            "overwriting": True,
+        }
+        self.assertTrue(modification(input))
+
+    def test_modification_with_invalid_data(self):
+        input = {
+            "action": "unknown",
+        }
+        with self.assertRaises(schema.SchemaError):
+            modification(input)

--- a/validator/schema/image_schema.py
+++ b/validator/schema/image_schema.py
@@ -1,19 +1,11 @@
 from validator import support
 from schema import Schema, Optional, Use, And, Or, SchemaError
+from validator.schema.modification_schema import modification
 
 
 def image_schema(file):
     valid_arches = [
         'x86_64',
-    ]
-
-    valid_modification_actions = [
-        'command',
-        'replace',
-    ]
-
-    valid_modification_commands = [
-        'update-console-sources',
     ]
 
     valid_distgit_namespaces = [
@@ -55,14 +47,7 @@ def image_schema(file):
                     },
                     'url': And(Use(str), len),
                 },
-                Optional('modifications'): [{
-                    'action': Or(*valid_modification_actions),
-                    Optional('command'): [
-                        Or(*valid_modification_commands),
-                    ],
-                    Optional('match'): And(str, len),
-                    Optional('replacement'): And(str, len),
-                }],
+                Optional('modifications'): [modification],
                 Optional('path'): str,
             },
         },

--- a/validator/schema/modification_schema.py
+++ b/validator/schema/modification_schema.py
@@ -1,0 +1,24 @@
+from schema import Schema, Optional, And, Or
+
+
+def modification(file):
+    valid_modification_actions = [
+        'command',
+        'replace',
+        'add',
+    ]
+
+    valid_modification_commands = [
+        'update-console-sources',
+    ]
+    return Schema({
+                  'action': Or(*valid_modification_actions),
+                  Optional('command'): [
+                      Or(*valid_modification_commands),
+                  ],
+                  Optional('match'): And(str, len),
+                  Optional('replacement'): And(str, len),
+                  Optional('source'): And(str, len),
+                  Optional('path'): And(str, len),
+                  Optional('overwriting'): bool,
+                  }).validate(file)

--- a/validator/schema/rpm_schema.py
+++ b/validator/schema/rpm_schema.py
@@ -1,5 +1,5 @@
 from schema import Schema, Optional, And, Or, Regex, SchemaError
-
+from validator.schema.modification_schema import modification
 valid_modes = [
     'auto',
     'disabled',
@@ -23,6 +23,7 @@ rpm_schema = Schema({
                 'url': And(str, len),
             },
             'specfile': Regex(r'.+\.spec$'),
+            Optional('modifications'): [modification],
         },
     },
     Optional('enabled_repos'): [


### PR DESCRIPTION
New modification action `add` is introduced by ART-948 to allow to add external out-of-tree sources into dist-git.
For more information, see https://jira.coreos.com/browse/ART-948.

Signed-off-by: Yuxiang Zhu <yuxzhu@redhat.com>