### PR TITLE
adding global session to prevent too many requests rate limit

### DIFF
--- a/validator/__main__.py
+++ b/validator/__main__.py
@@ -1,9 +1,11 @@
 from __future__ import print_function
-from multiprocessing import Pool, cpu_count
+
 import argparse
 import sys
+from multiprocessing import Pool, cpu_count
 
-from . import format, support, schema, github, distgit, exceptions
+from . import format, support, schema, github, distgit
+from . import exceptions, global_session
 
 
 def validate(file):
@@ -60,8 +62,9 @@ def main():
     else:
         try:
             rc = 0
-            Pool(cpu_count()).map(validate, args.files)
-
+            Pool(cpu_count(),
+                 initializer=global_session.set_global_session).map(
+                 validate, args.files)
         except exceptions.ValidationFailedWIP as e:
             print(str(e), file=sys.stderr)
 

--- a/validator/global_session.py
+++ b/validator/global_session.py
@@ -1,0 +1,9 @@
+import requests
+
+request_session = None
+
+
+def set_global_session():
+    global request_session
+    if not request_session:
+        request_session = requests.Session()

--- a/validator/support.py
+++ b/validator/support.py
@@ -3,6 +3,7 @@ import requests
 import yaml
 
 from . import exceptions
+from . import global_session
 
 
 def fail_validation(msg, parsed):
@@ -45,7 +46,11 @@ def get_valid_member_references_for(file):
 
 
 def resource_exists(url):
-    return 200 <= requests.head(url).status_code < 400
+    if global_session.request_session:
+        return 200 <= global_session.request_session\
+            .head(url).status_code < 400
+    else:
+        return 200 <= requests.head(url).status_code < 400
 
 
 def resource_is_reacheable(url):


### PR DESCRIPTION
Fixes https://github.com/openshift/ocp-build-data/pull/520 https://github.com/openshift/ocp-build-data/pull/519 https://github.com/openshift/ocp-build-data/pull/518 https://github.com/openshift/ocp-build-data/pull/517 https://github.com/openshift/ocp-build-data/pull/490 https://github.com/openshift/ocp-build-data/pull/447 https://github.com/openshift/ocp-build-data/pull/446

@thiagoalessio @vfreex @sosiouxme I don't exactly understand why our previous CI tests have not been caught by GitHub access rate limit but I am pretty sure if you curl 200+ images even with/without authentication will cause a problem (also I suspect base on IP or sth is there any change about or IP addresses from jenkins slaves? or maybe we used to have only one core so that multiple process acts like a single process so it shares one exact session?)  

this PR works 100% non-flaky at my local laptop.

```
[art@b05be634ff72 validate-ocp-build-data]$ validate-ocp-build-data  ocp-build-data/images/*
Validating ocp-build-data/images/atomic-openshift-cluster-autoscaler.yml
Validating ocp-build-data/images/csi-provisioner.yml
Validating ocp-build-data/images/elasticsearch-operator.yml
Validating ocp-build-data/images/atomic-openshift-descheduler.yml
Validating ocp-build-data/images/ghostunnel.yml
Validating ocp-build-data/images/baremetal-machine-controller.yml
Validating ocp-build-data/images/golang-github-openshift-oauth-proxy.yml
Validating ocp-build-data/images/baremetal-runtimecfg.yml
Validating ocp-build-data/images/golang-github-prometheus-alertmanager.yml
Validating ocp-build-data/images/cluster-etcd-operator.yml
Validating ocp-build-data/images/golang-github-prometheus-node_exporter.yml
Validating ocp-build-data/images/cluster-logging-operator.yml
Validating ocp-build-data/images/golang-github-prometheus-prometheus.yml
Validating ocp-build-data/images/cluster-monitoring-operator.yml
Validating ocp-build-data/images/grafana.yml
Validating ocp-build-data/images/cluster-network-operator.yml
Validating ocp-build-data/images/hadoop.yml
Validating ocp-build-data/images/cluster-nfd-operator.yml
Validating ocp-build-data/images/cluster-node-tuning-operator.yml
Validating ocp-build-data/images/hive.yml
Validating ocp-build-data/images/cluster-policy-controller.yml
Validating ocp-build-data/images/ironic-hardware-inventory-recorder-image.yml
Validating ocp-build-data/images/clusterresourceoverride-operator.yml
Validating ocp-build-data/images/ironic-inspector.yml
Validating ocp-build-data/images/ironic-ipa-downloader.yml
Validating ocp-build-data/images/clusterresourceoverride.yml
Validating ocp-build-data/images/cluster-storage-operator.yml
Validating ocp-build-data/images/ironic-rhcos-downloader.yml
Validating ocp-build-data/images/ironic-static-ip-manager.yml
Validating ocp-build-data/images/cluster-version-operator.yml
Validating ocp-build-data/images/configmap-reload.yml
Validating ocp-build-data/images/ironic.yml
Validating ocp-build-data/images/jenkins-agent-maven-35-rhel7.yml
Validating ocp-build-data/images/jenkins-agent-nodejs-10-rhel7.yml
Validating ocp-build-data/images/jenkins-agent-nodejs-8-rhel7.yml
Validating ocp-build-data/images/coredns.yml
Validating ocp-build-data/images/jenkins-slave-base-rhel7.yml
Validating ocp-build-data/images/csi-attacher.yml
Validating ocp-build-data/images/kube-proxy.yml
Validating ocp-build-data/images/csi-livenessprobe.yml
Validating ocp-build-data/images/kube-rbac-proxy.yml
Validating ocp-build-data/images/csi-node-driver-registrar.yml
Validating ocp-build-data/images/kube-state-metrics.yml
Validating ocp-build-data/images/kuryr-cni.yml
Validating ocp-build-data/images/openshift-enterprise-builder.yml
Validating ocp-build-data/images/openshift-enterprise-cli.yml
Validating ocp-build-data/images/kuryr-controller.yml
Validating ocp-build-data/images/openshift-enterprise-cluster-capacity.yml
Validating ocp-build-data/images/linuxptp-daemon.yml
Validating ocp-build-data/images/openshift-enterprise-console-operator.yml
Validating ocp-build-data/images/local-storage-diskmaker.yml
Validating ocp-build-data/images/local-storage-operator.yml
Validating ocp-build-data/images/openshift-enterprise-console.yml
Validating ocp-build-data/images/openshift-enterprise-deployer.yml
Validating ocp-build-data/images/local-storage-static-provisioner.yml
Validating ocp-build-data/images/openshift-enterprise-egress-dns-proxy.yml
Validating ocp-build-data/images/logging-curator5.yml
Validating ocp-build-data/images/openshift-enterprise-egress-router.yml
Validating ocp-build-data/images/logging-elasticsearch5.yml
Validating ocp-build-data/images/openshift-enterprise-haproxy-router.yml
Validating ocp-build-data/images/openshift-enterprise-hyperkube.yml
Validating ocp-build-data/images/logging-eventrouter.yml
Validating ocp-build-data/images/openshift-enterprise-keepalived-ipfailover.yml
Validating ocp-build-data/images/logging-fluentd.yml
Validating ocp-build-data/images/logging-kibana5.yml
Validating ocp-build-data/images/openshift-enterprise-pod.yml
Validating ocp-build-data/images/openshift-enterprise-registry.yml
Validating ocp-build-data/images/marketplace-operator.yml
Validating ocp-build-data/images/multus-cni.yml
Validating ocp-build-data/images/openshift-enterprise-service-catalog.yml
Validating ocp-build-data/images/openshift-enterprise-service-idler.yml
Validating ocp-build-data/images/node-feature-discovery.yml
Validating ocp-build-data/images/openshift-enterprise-template-service-broker-operator.yml
Validating ocp-build-data/images/openshift-enterprise-tests.yml
Validating ocp-build-data/images/oauth-server.yml
Validating ocp-build-data/images/openshift-jenkins-2.yml
Validating ocp-build-data/images/openshift-state-metrics.yml
Validating ocp-build-data/images/operator-lifecycle-manager.yml
Validating ocp-build-data/images/operator-registry.yml
Validating ocp-build-data/images/ose-aws-machine-controllers.yml
Validating ocp-build-data/images/ose-azure-machine-controllers.yml
Validating ocp-build-data/images/ose-baremetal-installer.yml
Validating ocp-build-data/images/ose-baremetal-operator.yml
Validating ocp-build-data/images/ose-cli-artifacts.yml
Validating ocp-build-data/images/openshift-enterprise-ansible-operator.yml
Validating ocp-build-data/images/ose-cloud-credential-operator.yml
Validating ocp-build-data/images/openshift-enterprise-base.yml
Validating ocp-build-data/images/ose-cluster-authentication-operator.yml
Validating ocp-build-data/images/ose-cluster-machine-approver.yml
Validating ocp-build-data/images/ose-cluster-autoscaler-operator.yml
Validating ocp-build-data/images/ose-cluster-openshift-apiserver-operator.yml
Validating ocp-build-data/images/ose-cluster-bootstrap.yml
Validating ocp-build-data/images/ose-cluster-openshift-controller-manager-operator.yml
Validating ocp-build-data/images/ose-cluster-samples-operator.yml
Validating ocp-build-data/images/ose-cluster-config-operator.yml
Validating ocp-build-data/images/ose-cluster-svcat-apiserver-operator.yml
Validating ocp-build-data/images/ose-cluster-csi-snapshot-controller-operator.yml
Validating ocp-build-data/images/ose-cluster-dns-operator.yml
Validating ocp-build-data/images/ose-cluster-svcat-controller-manager-operator.yml
Validating ocp-build-data/images/ose-cluster-update-keys.yml
Validating ocp-build-data/images/ose-cluster-image-registry-operator.yml
Validating ocp-build-data/images/ose-cluster-ingress-operator.yml
Validating ocp-build-data/images/ose-containernetworking-plugins.yml
Validating ocp-build-data/images/ose-csi-external-resizer.yml
Validating ocp-build-data/images/ose-cluster-kube-apiserver-operator.yml
Validating ocp-build-data/images/ose-csi-external-snapshotter.yml
Validating ocp-build-data/images/ose-cluster-kube-controller-manager-operator.yml
Validating ocp-build-data/images/ose-csi-snapshot-controller.yml
Validating ocp-build-data/images/ose-cluster-kube-descheduler-operator.yml
Validating ocp-build-data/images/ose-egress-http-proxy.yml
Validating ocp-build-data/images/ose-cluster-kube-scheduler-operator.yml
Validating ocp-build-data/images/ose-etcd.yml
Validating ocp-build-data/images/ose-cluster-kube-storage-version-migrator-operator.yml
Validating ocp-build-data/images/ose-gcp-machine-controllers.yml
Validating ocp-build-data/images/ose-kube-storage-version-migrator.yml
Validating ocp-build-data/images/ose-haproxy-router-base.yml
Validating ocp-build-data/images/ose-leader-elector.yml
Validating ocp-build-data/images/ose-libvirt-machine-controllers.yml
Validating ocp-build-data/images/ose-insights-operator.yml
Validating ocp-build-data/images/ose-installer-artifacts.yml
Validating ocp-build-data/images/ose-machine-api-operator.yml
Validating ocp-build-data/images/ose-installer.yml
```

```
[art@b05be634ff72 validate-ocp-build-data]$ validate-ocp-build-data  ocp-build-data/rpms/*
Validating ocp-build-data/rpms/machine-config-daemon.yml
Validating ocp-build-data/rpms/openshift-ansible.yml
Validating ocp-build-data/rpms/openshift-clients.yml
Validating ocp-build-data/rpms/openshift-enterprise-service-catalog.yml
Validating ocp-build-data/rpms/openshift-enterprise-service-idler.yml
Validating ocp-build-data/rpms/openshift-kuryr.yml
Validating ocp-build-data/rpms/openshift.yml
```
```
[art@b05be634ff72 ocp-build-data]$ validate-ocp-build-data images/atomic-openshift-cluster-autoscaler.yml images/atomic-openshift-descheduler.yml images/baremetal-machine-controller.yml images/baremetal-runtimecfg.yml images/cluster-logging-operator.yml images/cluster-monitoring-operator.yml images/cluster-network-operator.yml images/cluster-nfd-operator.yml images/cluster-node-tuning-operator.yml images/cluster-storage-operator.yml images/cluster-version-operator.yml images/configmap-reload.yml images/coredns.yml images/csi-attacher.yml images/csi-livenessprobe.yml images/csi-node-driver-registrar.yml images/csi-provisioner.yml images/descheduler-operator.yml images/efs-provisioner.yml images/elasticsearch-operator.yml images/ghostunnel.yml images/golang-github-openshift-oauth-proxy.yml images/golang-github-prometheus-alertmanager.yml images/golang-github-prometheus-node_exporter.yml images/golang-github-prometheus-prometheus.yml images/grafana.yml images/hadoop.yml images/hive.yml images/ironic-inspector.yml images/ironic-ipa-downloader.yml images/ironic-rhcos-downloader.yml images/ironic-static-ip-manager.yml images/ironic.yml images/jenkins-agent-maven-35-rhel7.yml images/jenkins-agent-nodejs-8-rhel7.yml images/jenkins-slave-base-rhel7.yml images/kube-proxy.yml images/kube-rbac-proxy.yml images/kube-state-metrics.yml images/kuryr-cni.yml images/kuryr-controller.yml images/local-storage-diskmaker.yml images/local-storage-operator.yml images/local-storage-static-provisioner.yml images/logging-curator5.yml images/logging-elasticsearch5.yml images/logging-eventrouter.yml images/logging-fluentd.yml images/logging-kibana5.yml images/marketplace-operator.yml images/multus-cni.yml images/node-feature-discovery.yml images/oauth-server.yml images/openshift-enterprise-ansible-operator.yml images/openshift-enterprise-ansible-service-broker-operator.yml images/openshift-enterprise-apb-base.yml images/openshift-enterprise-apb.yml images/openshift-enterprise-asb.yml images/openshift-enterprise-base.yml images/openshift-enterprise-builder.yml images/openshift-enterprise-cli.yml images/openshift-enterprise-cluster-capacity.yml images/openshift-enterprise-console-operator.yml images/openshift-enterprise-console.yml images/openshift-enterprise-deployer.yml images/openshift-enterprise-egress-dns-proxy.yml images/openshift-enterprise-egress-router.yml images/openshift-enterprise-haproxy-router.yml images/openshift-enterprise-hyperkube.yml images/openshift-enterprise-keepalived-ipfailover.yml images/openshift-enterprise-mariadb.yml images/openshift-enterprise-mediawiki.apb.yml images/openshift-enterprise-mediawiki.container.yml images/openshift-enterprise-mysql.yml images/openshift-enterprise-pod.yml images/openshift-enterprise-postgresql.yml images/openshift-enterprise-recycler.yml images/openshift-enterprise-registry.yml images/openshift-enterprise-service-catalog.yml
Validating images/atomic-openshift-cluster-autoscaler.yml
Validating images/cluster-version-operator.yml
Validating images/configmap-reload.yml
Validating images/coredns.yml
Validating images/atomic-openshift-descheduler.yml
Validating images/csi-attacher.yml
Validating images/baremetal-machine-controller.yml
Validating images/csi-livenessprobe.yml
Validating images/baremetal-runtimecfg.yml
Validating images/csi-node-driver-registrar.yml
Validating images/cluster-logging-operator.yml
Validating images/csi-provisioner.yml
Validating images/cluster-monitoring-operator.yml
Validating images/descheduler-operator.yml
Validating images/ghostunnel.yml
Validating images/cluster-network-operator.yml
Validating images/golang-github-openshift-oauth-proxy.yml
Validating images/cluster-nfd-operator.yml
Validating images/golang-github-prometheus-alertmanager.yml
Validating images/cluster-node-tuning-operator.yml
Validating images/golang-github-prometheus-node_exporter.yml
Validating images/cluster-storage-operator.yml
Validating images/golang-github-prometheus-prometheus.yml
Validating images/ironic-rhcos-downloader.yml
Validating images/grafana.yml
Validating images/ironic-static-ip-manager.yml
Validating images/hadoop.yml
Validating images/ironic.yml
Validating images/jenkins-agent-maven-35-rhel7.yml
Validating images/hive.yml
Validating images/ironic-inspector.yml
Validating images/jenkins-agent-nodejs-8-rhel7.yml
Validating images/ironic-ipa-downloader.yml
Validating images/jenkins-slave-base-rhel7.yml
Validating images/kuryr-controller.yml
Validating images/kube-proxy.yml
Validating images/local-storage-diskmaker.yml
Validating images/kube-rbac-proxy.yml
Validating images/local-storage-operator.yml
Validating images/kube-state-metrics.yml
Validating images/local-storage-static-provisioner.yml
Validating images/kuryr-cni.yml
Validating images/logging-curator5.yml
Validating images/multus-cni.yml
Validating images/logging-elasticsearch5.yml
Validating images/openshift-enterprise-cli.yml
Validating images/node-feature-discovery.yml
Validating images/openshift-enterprise-cluster-capacity.yml
Validating images/oauth-server.yml
Validating images/openshift-enterprise-mariadb.yml
Validating images/openshift-enterprise-console-operator.yml
Validating images/openshift-enterprise-console.yml
Validating images/openshift-enterprise-deployer.yml
Validating images/openshift-enterprise-egress-dns-proxy.yml
Validating images/openshift-enterprise-egress-router.yml
Validating images/openshift-enterprise-haproxy-router.yml
Validating images/openshift-enterprise-hyperkube.yml
Validating images/openshift-enterprise-keepalived-ipfailover.yml
[Errno 2] No such file or directory: 'images/descheduler-operator.yml'
```