### PR TITLE
make schema content.source.git.url stick to format git@host:org/repo.git

### DIFF
--- a/tests/test_schema/test_image_schema.py
+++ b/tests/test_schema/test_image_schema.py
@@ -36,3 +36,55 @@ class TestImageSchema(unittest.TestCase):
         }
         self.assertEqual("Key 'name' error:\n1234 should be instance of 'str'",
                          image_schema.validate('filename', invalid_data))
+
+    def test_validate_with_invalid_content_source_git_url(self):
+        (flexmock(image_schema.support)
+            .should_receive('get_valid_streams_for')
+            .and_return([]))
+
+        (flexmock(image_schema.support)
+            .should_receive('get_valid_member_references_for')
+            .and_return([]))
+
+        url = 'https://github.com/openshift/csi-node-driver-registrar'
+        invalid_data = {
+            'content': {
+                'source': {
+                    'git': {
+                        'branch': {
+                            'target': 'test',
+                        },
+                        'url': url
+                    }
+                }
+            },
+            'name': '1234',
+            'from': {},
+        }
+        self.assertIn("Key 'content' error:\nKey", image_schema.validate('filename', invalid_data))
+
+    def test_validate_with_valid_content_source_git_url(self):
+        (flexmock(image_schema.support)
+            .should_receive('get_valid_streams_for')
+            .and_return([]))
+
+        (flexmock(image_schema.support)
+            .should_receive('get_valid_member_references_for')
+            .and_return([]))
+
+        url = 'git@github.com:openshift/csi-node-driver-registrar.git'
+        valid_data = {
+            'content': {
+                'source': {
+                    'git': {
+                        'branch': {
+                            'target': 'test',
+                        },
+                        'url': url
+                    }
+                }
+            },
+            'name': '1234',
+            'from': {},
+        }
+        self.assertIsNone(image_schema.validate('filename', valid_data))

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,9 @@ commands =
     flake8
     coverage run --branch --source validator -m unittest discover
     coverage report
+
+[flake8]
+# E501 line too long (88 > 79 characters)
+# E741 ambiguous variable name 'l' (don't modify benhcmarks just for that)
+# W503 line break before binary operator
+ignore = E501,E741,W503,E126,E121

--- a/validator/schema/image_schema.py
+++ b/validator/schema/image_schema.py
@@ -1,6 +1,8 @@
 from validator import support
-from schema import Schema, Optional, Use, And, Or, SchemaError
+from schema import Schema, Optional, And, Or, Regex, SchemaError
 from validator.schema.modification_schema import modification
+
+GIT_SSH_URL_REGEX = r'((git@[\w\.]+))([\w\.@\:/\-~]+)(\.git)(/)?'
 
 
 def image_schema(file):
@@ -46,7 +48,7 @@ def image_schema(file):
                         Optional('fallback'): And(str, len),
                         'target': And(str, len),
                     },
-                    'url': And(Use(str), len),
+                    'url': And(str, len, Regex(GIT_SSH_URL_REGEX)),
                 },
                 Optional('modifications'): [modification],
                 Optional('path'): str,

--- a/validator/schema/rpm_schema.py
+++ b/validator/schema/rpm_schema.py
@@ -1,5 +1,9 @@
 from schema import Schema, Optional, And, Or, Regex, SchemaError
 from validator.schema.modification_schema import modification
+
+
+GIT_SSH_URL_REGEX = r'((git@[\w\.]+))([\w\.@\:/\-~]+)(\.git)(/)?'
+
 valid_modes = [
     'auto',
     'disabled',
@@ -20,7 +24,7 @@ rpm_schema = Schema({
                     Optional('fallback'): And(str, len),
                     'target': And(str, len),
                 },
-                'url': And(str, len),
+                'url': And(str, len, Regex(GIT_SSH_URL_REGEX)),
             },
             'specfile': Regex(r'.+\.spec$'),
             Optional('modifications'): [modification],


### PR DESCRIPTION
enforce CI to check errors like this https://github.com/openshift/ocp-build-data/pull/526 