### PR TITLE
Do not retry on 404s

### DIFF
--- a/validator/global_session.py
+++ b/validator/global_session.py
@@ -6,7 +6,7 @@ request_session = None
 
 retry_strategy = Retry(
     total=3,
-    status_forcelist=[404, 429, 500, 502, 503, 504],
+    status_forcelist=[429, 500, 502, 503, 504],
     method_whitelist=["HEAD", "GET", "OPTIONS"]
 )
 adapter = HTTPAdapter(max_retries=retry_strategy)


### PR DESCRIPTION
This fixes the validation bug caused by retrying on 404s, in a case where a github branch does not exist. We want to get the 404 to detect a non-existent branch and then use the fallback branch.