### PR TITLE
Change version to 0.2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setuptools.setup(
     name='rh-ocp-build-data-validator',
     author='AOS ART Team',
     author_email='aos-team-art@redhat.com',
-    version='0.2.1',
+    version='0.2.2',
     description='Validation of ocp-build-data Image & RPM declarations',
     long_description_content_type='text/x-rst',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
We need to create a new tag to let Jenkins publish new tool version to Pypi. This PR updates the setup.py file to define new version 0.2.2