### PR TITLE
Use JSON Schema to annotate and validate releases.yml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include requirements.txt
 include README.rst
-incluade validator/*
+include validator/json_schemas/*

--- a/SETUP_EDITOR.md
+++ b/SETUP_EDITOR.md
@@ -1,0 +1,27 @@
+# Setup Your Editor for Auto-completion and instantaneous validation
+
+## Visual Studio Code (VSCode)
+- Install the [YAML][1] plugin.
+- Open `ocp-build-data` project.
+- Add the following config options to `.vscode/settings.json`:
+    ```json
+    {
+        "yaml.schemas": {
+            "/path/to/json_schemas/releases.schema.json": "/releases.yml",
+        }
+    }
+    ```
+- Open `releases.yml`.
+
+## PyCharm (or other Intellij IDEA based IDEs)
+- Open `ocp-build-data` project.
+- Go to `Preferences | Languages & Frameworks | Schemas and DTDs | JSON Schema Mappings`.
+- Click `+`. Add a JSON schema mapping as the following:
+  - *Name* Choose a friendly name. e.g. `OCP releases`
+  - *Schema file or URL* The path to `json_schemas/releases.schema.json`
+  - *Schema version* Choose `JSON Schema version 7`
+  - Click `+`, choose `Add file`, type `releases.yml`, and press `Return`.
+- Open `releases.yml`.
+
+
+[1]: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ idna==2.9
 importlib-metadata==1.6.1
 importlib-resources==1.5.0
 jeepney==0.4.3
+jsonschema ~= 4.4.0
 keyring==21.2.1
 packaging==20.4
 pkginfo==1.5.0.1

--- a/validator/json_schemas/arches.schema.json
+++ b/validator/json_schemas/arches.schema.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "array",
+    "items": {
+        "type": "string",
+        "enum": ["x86_64", "s390x", "ppc64le", "aarch64"]
+    }
+}

--- a/validator/json_schemas/arches_dict.schema.json
+++ b/validator/json_schemas/arches_dict.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "x86_64": {
+      "type": "string",
+      "minLength": 1
+    },
+    "s390x": {
+      "type": "string",
+      "minLength": 1
+    },
+    "ppc64le": {
+      "type": "string",
+      "minLength": 1
+    },
+    "aarch64": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/validator/json_schemas/assembly.schema.json
+++ b/validator/json_schemas/assembly.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Assembly",
+  "description": "An assembly represents unambiguous, programmatic instructions on how to build and rebuild a release payload at any point in the future.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "Type of the assembly. Default value: stream",
+      "type": "string",
+      "enum": [
+        "stream",
+        "standard",
+        "candidate",
+        "custom"
+      ]
+    },
+    "basis": {
+      "description": "Basis of the assembly",
+      "$ref": "assembly_basis.schema.json"
+    },
+    "group": {
+      "description": "Group configuration overrides for the assembly",
+      "$ref": "assembly_group_config.schema.json"
+    },
+    "members": {
+      "description": "Members of the assembly",
+      "type": "object",
+      "properties": {
+        "images": {
+          "type": "array",
+          "items": {
+            "$ref": "member_image.schema.json"
+          }
+        },
+        "rpms": {
+          "type": "array",
+          "items": {
+            "$ref": "member_rpm.schema.json"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "rhcos": {
+      "description": "RHCOS configuration for the assembly",
+      "$ref": "rhcos.schema.json"
+    },
+    "streams": {
+      "$ref": "streams.schema.json"
+    },
+    "permits": {
+      "description": "Permits assembly errors. See https://github.com/openshift-eng/art-docs/blob/master/content/assemblies.md#permissible-issues for more information.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "The error code to permit",
+            "type": "string",
+            "minLength": 1
+          },
+          "component": {
+            "description": "Name of the component that this permit applies to. Use '*' to permit all components.",
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "code",
+          "component"
+        ]
+      }
+    },
+    "promotion_permits": {
+      "description": "Permits promotion errors. See https://github.com/openshift/aos-cd-jobs/tree/master/jobs/build/promote-assembly#permit-certain-validation-failures for more information.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "The error code to permit",
+            "type": "string",
+            "minLength": 1
+          },
+          "why": {
+            "description": "The reason why this error should be permitted. Note this text is public. Don't include customer related or confidential information.",
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "code",
+          "why"
+        ]
+      }
+    },
+    "issues": {
+      "description": "Bugs and JIRA issues to included or exclude for advisories",
+      "$ref": "assembly_issues.schema.json"
+    }
+  },
+  "additionalProperties": false
+}

--- a/validator/json_schemas/assembly_basis.schema.json
+++ b/validator/json_schemas/assembly_basis.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Basis of the assembly",
+  "description": "Basis ties the release to a particular moment, existing release, or another release.",
+  "type": "object",
+  "properties": {
+    "brew_event": {
+      "description": "A Brew event that ties the release to a particular moment. Images and rpms will be assembled relative to This basis event.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "assembly": {
+      "description": "The parent assembly to inherit from",
+      "type": "string",
+      "minLength": 1
+    },
+    "reference_releases": {
+      "description": "Indicates this release should be assembled with specified existing release images",
+      "$ref": "arches_dict.schema.json"
+    },
+    "reference_releases!": {
+      "$ref": "#/properties/reference_releases"
+    },
+    "reference_releases?": {
+      "$ref": "#/properties/reference_releases"
+    },
+    "reference_releases-": {
+    }
+  },
+  "additionalProperties": false
+}

--- a/validator/json_schemas/assembly_dependencies.schema.json
+++ b/validator/json_schemas/assembly_dependencies.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "rpms": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "why": {
+            "type": "string"
+          },
+          "non_gc_tag": {
+            "type": "string"
+          }
+        },
+        "patternProperties": {
+          "^el\\d+[!?-]?$": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "why",
+          "non_gc_tag"
+        ],
+        "minProperties": 3,
+        "additionalProperties": false
+      }
+    },
+    "rpms!": {
+      "$ref": "#/properties/rpms"
+    },
+    "rpms?": {
+      "$ref": "#/properties/rpms"
+    }
+  },
+  "anyOf": [
+    {
+      "required": [
+        "rpms"
+      ]
+    },
+    {
+      "required": [
+        "rpms!"
+      ]
+    },
+    {
+      "required": [
+        "rpms?"
+      ]
+    }
+  ],
+  "additionalProperties": false
+}

--- a/validator/json_schemas/assembly_group_config.schema.json
+++ b/validator/json_schemas/assembly_group_config.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "arches": {
+      "$ref": "arches.schema.json"
+    },
+    "arches!": {
+      "$ref": "#/properties/arches"
+    },
+    "arches?": {
+      "$ref": "#/properties/arches"
+    },
+    "arches-": {},
+    "repos": {
+      "$ref": "repos.schema.json"
+    },
+    "repos!": {
+      "$ref": "#/properties/repos"
+    },
+    "repos?": {
+      "$ref": "#/properties/repos"
+    },
+    "repos-": {},
+    "advisories": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": "integer"
+        },
+        "image!": {
+          "$ref": "#/properties/advisories/properties/image"
+        },
+        "image?": {
+          "$ref": "#/properties/advisories/properties/image"
+        },
+        "image-": {},
+        "rpm": {
+          "type": "integer"
+        },
+        "rpm!": {
+          "$ref": "#/properties/advisories/properties/rpm"
+        },
+        "rpm?": {
+          "$ref": "#/properties/advisories/properties/rpm"
+        },
+        "rpm-": {},
+        "extras": {
+          "type": "integer"
+        },
+        "extras!": {
+          "$ref": "#/properties/advisories/properties/extras"
+        },
+        "extras?": {
+          "$ref": "#/properties/advisories/properties/extras"
+        },
+        "extras-": {},
+        "metadata": {
+          "type": "integer"
+        },
+        "metadata!": {
+          "$ref": "#/properties/advisories/properties/metadata"
+        },
+        "metadata?": {
+          "$ref": "#/properties/advisories/properties/metadata"
+        },
+        "metadata-": {}
+      },
+      "additionalProperties": false
+    },
+    "advisories!": {
+      "$ref": "#/properties/advisories"
+    },
+    "advisories?": {
+      "$ref": "#/properties/advisories"
+    },
+    "advisories-": {},
+    "dependencies": {
+      "$ref": "assembly_dependencies.schema.json"
+    },
+    "dependencies!": {
+      "$ref": "#/properties/dependencies"
+    },
+    "dependencies?": {
+      "$ref": "#/properties/dependencies"
+    },
+    "dependencies-": {},
+    "release_jira": {
+      "type": "string",
+      "minLength": 1
+    },
+    "release_jira!": {
+      "$ref": "#/properties/release_jira"
+    },
+    "release_jira?": {
+      "$ref": "#/properties/release_jira"
+    },
+    "release_jira-": {},
+    "upgrades": {
+      "type": "string"
+    },
+    "upgrades!": {
+      "$ref": "#/properties/upgrades"
+    },
+    "upgrades?": {
+      "$ref": "#/properties/upgrades"
+    },
+    "upgrades-": {},
+    "check_golang_versions": {
+      "type": "boolean"
+    },
+    "check_golang_versions!": {
+      "$ref": "#/properties/check_golang_versions"
+    },
+    "check_golang_versions?": {
+      "$ref": "#/properties/check_golang_versions"
+    },
+    "check_golang_versions-": {},
+    "cachito": {
+      "description": "Cachito integration configuration",
+      "$ref": "cachito.schema.json"
+    },
+    "cachito!": {
+      "$ref": "#/properties/cachito"
+    },
+    "cachito?": {
+      "$ref": "#/properties/cachito"
+    },
+    "cachito-": {}
+  },
+  "additionalProperties": false
+}

--- a/validator/json_schemas/assembly_issues.schema.json
+++ b/validator/json_schemas/assembly_issues.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "include": {
+      "description": "Bugs or JIRA issues to include",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Bug ID (integer) or JIRA issue key (string)",
+            "oneOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "pattern": "^[A-Z]+-\\d+$"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "id"
+        ]
+      }
+    },
+    "include!": {
+      "$ref": "#/properties/include"
+    },
+    "include?": {
+      "$ref": "#/properties/include"
+    },
+    "include-": {},
+    "exclude": {
+      "description": "Bugs or JIRA issues to exclude",
+      "$ref": "#/properties/include"
+    },
+    "exclude!": {
+      "$ref": "#/properties/exclude"
+    },
+    "exclude?": {
+      "$ref": "#/properties/exclude"
+    },
+    "exclude-": {},
+    "additionalProperties": false
+  }
+}

--- a/validator/json_schemas/cachito.schema.json
+++ b/validator/json_schemas/cachito.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "description": "Cachito integration configuration",
+  "properties": {
+    "enabled": {
+      "type": "boolean",
+      "description": "True to enable Cachito support. Default value: false"
+    },
+    "enabled-": {},
+    "flags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "flags!": {
+      "$ref": "#/properties/flags"
+    },
+    "flags?": {
+      "$ref": "#/properties/flags"
+    },
+    "flags-": {}
+  },
+  "additionalProperties": false
+}

--- a/validator/json_schemas/member_image.schema.json
+++ b/validator/json_schemas/member_image.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "distgit_key": {
+      "type": "string",
+      "minLength": 1
+    },
+    "why": {
+      "type": "string",
+      "minLength": 1
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "content": {
+          "type": "object",
+          "$comment": "TODO: Validate image content config",
+          "additionalProperties": true
+        },
+        "content!": {
+          "$ref": "#/properties/metadata/properties/content"
+        },
+        "content?": {
+          "$ref": "#/properties/metadata/properties/content"
+        },
+        "content-": {},
+        "container_yaml": {
+          "type": "object"
+        },
+        "container_yaml!": {
+          "$ref": "#/properties/metadata/properties/container_yaml"
+        },
+        "container_yaml?": {
+          "$ref": "#/properties/metadata/properties/container_yaml"
+        },
+        "container_yaml-": {},
+        "cachito": {
+          "description": "Cachito integration configuration",
+          "$ref": "cachito.schema.json"
+        },
+        "cachito!": {
+          "$ref": "#/properties/metadata/properties/cachito"
+        },
+        "cachito?": {
+          "$ref": "#/properties/metadata/properties/cachito"
+        },
+        "cachito-": {},
+        "dependencies": {
+          "$ref": "assembly_dependencies.schema.json"
+        },
+        "dependencies!": {
+          "$ref": "#/properties/metadata/properties/dependencies"
+        },
+        "dependencies?": {
+          "$ref": "#/properties/metadata/properties/dependencies"
+        },
+        "dependencies-": {},
+        "is": {
+          "type": "object",
+          "properties": {
+            "nvr": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "nvr"
+          ],
+          "additionalProperties": false
+        },
+        "is!": {
+          "$ref": "#/properties/metadata/properties/is"
+        },
+        "is?": {
+          "$ref": "#/properties/metadata/properties/is"
+        },
+        "is-": {}
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "distgit_key",
+    "why"
+  ],
+  "additionalProperties": false
+}

--- a/validator/json_schemas/member_rpm.schema.json
+++ b/validator/json_schemas/member_rpm.schema.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "distgit_key": {
+            "type": "string",
+            "minLength": 1
+        },
+        "why": {
+            "type": "string",
+            "minLength": 1
+        },
+        "metadata": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "object",
+                    "$comment": "TODO: Validate rpm content config",
+                    "additionalProperties": true
+                },
+                "content!": {
+                    "$ref": "#/properties/metadata/properties/content"
+                },
+                "content?": {
+                    "$ref": "#/properties/metadata/properties/content"
+                },
+                "content-": {},
+                "is": {
+                    "type": "object",
+                    "properties": {
+                        "el8": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "el7": {
+                            "$ref": "#/properties/metadata/properties/is/properties/el8"
+                        }
+                    },
+                    "patternProperties": {
+                        "^el\\d+[!?-]?$": {
+                            "$ref": "#/properties/metadata/properties/is/properties/el8"
+                        }
+                    },
+                    "minProperties": 1,
+                    "additionalProperties": false
+                },
+                "is!": {
+                    "$ref": "#/properties/metadata/properties/is"
+                },
+                "is?": {
+                    "$ref": "#/properties/metadata/properties/is"
+                },
+                "is-": {}
+            },
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "distgit_key",
+        "why"
+    ],
+    "additionalProperties": false
+}

--- a/validator/json_schemas/release.schema.json
+++ b/validator/json_schemas/release.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Release",
+  "description": "A release",
+  "type": "object",
+  "properties": {
+    "assembly": {
+      "$ref": "assembly.schema.json"
+    }
+  },
+  "required": [
+    "assembly"
+  ],
+  "additionalProperties": false
+}

--- a/validator/json_schemas/releases.schema.json
+++ b/validator/json_schemas/releases.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "releases": "Releases",
+  "description": "Releases object contains information on every release that ART promotes as GA and every custom hotfix it delivers to customers.",
+  "type": "object",
+  "properties": {
+    "releases": {
+      "description": "An object containing all releases in a group.",
+      "type": "object",
+      "patternProperties": {
+        "^stream$|^test$|^art\\d+$|^\\d+\\.\\d+\\.\\d+$|^[fr]c\\.\\d+$": {
+          "$ref": "release.schema.json"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "releases"
+  ]
+}

--- a/validator/json_schemas/repos.schema.json
+++ b/validator/json_schemas/repos.schema.json
@@ -1,0 +1,72 @@
+{
+    "type": "object",
+    "$defs": {
+        "repo": {
+            "type": "object",
+            "properties": {
+                "conf": {
+                    "type": "object",
+                    "properties": {
+                        "baseurl": {
+                            "$ref": "arches_dict.schema.json"
+                        },
+                        "baseurl!": {
+                            "$ref": "#/$defs/repo/properties/conf/properties/baseurl"
+                        },
+                        "baseurl?": {
+                            "$ref": "#/$defs/repo/properties/conf/properties/baseurl"
+                        }
+                    },
+                    "anyOf": [
+                        {
+                            "required": [
+                                "baseurl"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "baseurl!"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "baseurl?"
+                            ]
+                        }
+                    ],
+                    "additionalProperties": false
+                },
+                "conf!": {
+                    "$ref": "#/$defs/repo/properties/conf"
+                },
+                "conf?": {
+                    "$ref": "#/$defs/repo/properties/conf"
+                }
+            },
+            "anyOf": [
+                {
+                    "required": [
+                        "conf"
+                    ]
+                },
+                {
+                    "required": [
+                        "conf!"
+                    ]
+                },
+                {
+                    "required": [
+                        "conf?"
+                    ]
+                }
+            ],
+            "additionalProperties": false
+        }
+    },
+    "patternProperties": {
+        "^.+$": {
+            "$ref": "#/$defs/repo"
+        }
+    },
+    "additionalProperties": false
+}

--- a/validator/json_schemas/rhcos.schema.json
+++ b/validator/json_schemas/rhcos.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "RHCOS images for the assembly.",
+  "type": "object",
+  "properties": {
+    "machine-os-content": {
+      "type": "object",
+      "properties": {
+        "images": {
+          "$ref": "arches_dict.schema.json"
+        },
+        "images!": {
+          "$ref": "#/properties/machine-os-content/properties/images"
+        },
+        "images?": {
+          "$ref": "#/properties/machine-os-content/properties/images"
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "images"
+          ]
+        },
+        {
+          "required": [
+            "images?"
+          ]
+        },
+        {
+          "required": [
+            "images!"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "machine-os-content!": {
+      "$ref": "#/properties/machine-os-content"
+    },
+    "machine-os-content?": {
+      "$ref": "#/properties/machine-os-content"
+    },
+    "dependencies": {
+      "$ref": "assembly_dependencies.schema.json"
+    },
+    "dependencies!": {
+      "$ref": "#/properties/dependencies"
+    },
+    "dependencies?": {
+      "$ref": "#/properties/dependencies"
+    },
+    "dependencies-": {}
+  },
+  "anyOf": [
+    {
+      "required": [
+        "machine-os-content"
+      ]
+    },
+    {
+      "required": [
+        "machine-os-content!"
+      ]
+    },
+    {
+      "required": [
+        "machine-os-content?"
+      ]
+    }
+  ],
+  "additionalProperties": false
+}

--- a/validator/json_schemas/streams.schema.json
+++ b/validator/json_schemas/streams.schema.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+        "stream": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "upstream_image_base": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "upstream_image": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "mirror": {
+                    "type": "boolean"
+                },
+                "transform": {
+                    "type": "string",
+                    "minLength": 1
+                }
+            },
+            "required": [
+                "image",
+                "upstream_image"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "type": "object",
+    "patternProperties": {
+        "^.+$": {
+            "$ref": "#/$defs/stream"
+        }
+    },
+    "additionalProperties": false
+}

--- a/validator/schema/releases_schema.py
+++ b/validator/schema/releases_schema.py
@@ -1,137 +1,18 @@
-from schema import Schema, Optional, And, Or, Regex, SchemaError
-from validator.schema.image_schema import IMAGE_CONTENT_SCHEMA
-from validator.schema.rpm_schema import RPM_CONTENT_SCHEMA
-from validator.schema.streams_schema import STREAMS_SCHEMA
+import json
+import sys
 
-GIT_SSH_URL_REGEX = r'((git@[\w\.]+))([\w\.@\:/\-~]+)(\.git)(/)?'
-UPGRADE_EDGES_REGEX = r'\d+\.\d+\.\d+(?:-[fr]c\.\d+)?(,\d+\.\d+\.\d+(?:-[fr]c\.\d+)?)*'
+from jsonschema import RefResolver, ValidationError
+from jsonschema.validators import validator_for
 
-ASSEMBLY_DEPENDENCIES = {
-    'rpms': [
-        And({
-            Regex(r'el\d+'): str,  # Each RHEL version can have its own
-            'why': str,  # Human description of why this is being added for historical purposes
-            'non_gc_tag': str,  # Artist should provide tag they know will prevent this NVR from garbage collection.
-        })
-    ]
-}
+from schema import SchemaError
 
-ASSEMBLY_NAME_REGEX = Or(Regex(r'^art\d+$'), Regex(r'^\d+\.\d+\.\d+$'), Regex(r'^rc\.\d+$'), Regex(r'^fc\.\d+$'))
-ARCHES = Or('x86_64', 'ppc64le', 's390x', 'aarch64')
-ARCHES_DICT = {
-    Optional('x86_64'): str,
-    Optional('s390x'): str,
-    Optional('ppc64le'): str,
-    Optional('aarch64'): str,
-}
-
-
-def releases_schema(file):
-    return Schema({
-        'releases': {
-            Optional(Or('stream', 'test', ASSEMBLY_NAME_REGEX)): {
-                'assembly': {
-                    Optional('type'): Or('standard', 'custom', 'candidate', 'stream'),
-                    Optional('basis'): {
-                        Optional('brew_event'): int,
-                        Optional('assembly'): ASSEMBLY_NAME_REGEX,
-
-                        # If specified, when generating a release payload, "oc adm release new" will be run with from-release.
-                        # However, the basis brew_event is still king and all images found in the nightlies
-                        # must align perfectly with the basis & machine-os-content images of the assembly
-                        # or an error will be thrown. Why? Nightly records can be lost. We need to be able to
-                        # reconstruct from a source of truth.
-                        # If not specified, oc release new will not be passed from-release.
-                        Optional('reference_releases'): ARCHES_DICT,  # per-arch nightly names
-                    },
-                    Optional('permits'): [  # A list of issues that this assembly permits during payload generation.
-                        And({
-                            'code': Regex('[A-Z0-9_]+'),
-                            'component': str,  # A component name or '*'
-                        })
-                    ],
-                    Optional('promotion_permits'): [  # A list of issues that this assembly permits during payload promotion.
-                        And({
-                            'code': Regex('[A-Z0-9_]+'),
-                            'why': str,  # A component name or '*'
-                        })
-                    ],
-                    Optional('rhcos'): {
-                        'machine-os-content': {
-                            'images': ARCHES_DICT,  # pullspecs for arch specific images
-                        },
-                        Optional('dependencies'): ASSEMBLY_DEPENDENCIES,
-                    },
-                    Optional('streams'): STREAMS_SCHEMA,
-                    Optional('group'): {
-                        Optional('arches'): [ARCHES],
-                        Optional('repos'): {
-                            Regex('[a-z0-9.-]+'): {
-                                'conf': {
-                                    'baseurl': {
-                                        ARCHES: str,
-                                    }
-                                }
-                            }
-                        },
-                        Optional('advisories'): {
-                            Optional('image'): int,
-                            Optional('rpm'): int,
-                            Optional('extras'): int,
-                            Optional('metadata'): int,
-                        },
-                        Optional('dependencies'): ASSEMBLY_DEPENDENCIES,
-                        Optional('release_jira'): str,
-                        Optional('upgrades'): Regex(UPGRADE_EDGES_REGEX),
-                        Optional('cachito'): {
-                            Optional('enabled'): bool,
-                            Optional('flags'): [str],
-                        },
-                    },
-                    Optional('members'): {
-                        Optional('rpms'): [
-                            And({
-                                'distgit_key': str,
-                                'why': str,  # Human description of why this is being added for historical purposes
-                                Optional('metadata'): {
-                                    Optional('content'): RPM_CONTENT_SCHEMA,
-                                    Optional('is'): {
-                                        Regex(r'el\d+'): str
-                                    }
-                                },
-                            })
-                        ],
-                        Optional('images'): [
-                            And({
-                                'distgit_key': str,
-                                'why': str,  # Human description of why this is being added for historical purposes
-                                Optional('metadata'): {
-                                    Optional('container_yaml'): object,
-                                    Optional('content'): IMAGE_CONTENT_SCHEMA,
-                                    Optional('dependencies'): ASSEMBLY_DEPENDENCIES,
-                                    Optional('is'): {
-                                        'nvr': str
-                                    },
-                                },
-                            })
-                        ]
-                    },
-                    Optional('issues'): {
-                        Optional('include'): [
-                            And({
-                                'id': Or(int, Regex(r'[A-Z]+-\d+'))  # bugzilla or Jira
-                            })
-                        ],
-                        Optional('exclude'): [
-                            And({
-                                'id': Or(int, Regex(r'[A-Z]+-\d+'))  # bugzilla or Jira
-                            })
-                        ],
-                    },
-                },
-            }
-        }
-    })
+if sys.version_info < (3, 9):
+    # importlib.resources either doesn't exist or lacks the files()
+    # function, so use the PyPI version:
+    import importlib_resources
+else:
+    # importlib.resources has files(), so use that:
+    import importlib.resources as importlib_resources
 
 
 def _demerge(data):
@@ -158,8 +39,17 @@ def _demerge(data):
     raise TypeError(f"Unexpected value type: {type(data)}: {data}")
 
 
-def validate(file, data):
+def validate(_, data):
+    # Load Json schemas
+    path = importlib_resources.files("validator") / "json_schemas"
+    schemas = {source.name: json.load(open(source)) for source in path.iterdir() if source.name.endswith(".json")}
+    schema_store = {schema.get("$id", filename): schema for filename, schema in schemas.items()}
+    schema = schema_store["releases.schema.json"]
+    resolver = RefResolver.from_schema(schema, store=schema_store)
+    validator = validator_for(schema)(schema, resolver=resolver)
+    demerged_data = _demerge(data)
+    # Validate with JSON schemas
     try:
-        releases_schema(file).validate(_demerge(data))
-    except SchemaError as err:
-        return '{}'.format(err)
+        validator.validate(demerged_data)
+    except ValidationError as err:
+        return str(err)


### PR DESCRIPTION
Those JSON schema files can also be configured on editors or IDEs to support
auto-completion and instantaneous validation.

Note `releases.yml` may contain special fields (ending with `?` `!` `-`) for assembly inheritance.
In the future we may use Doozer to fill in the inherited fields and then run the output through the schema check, rather than try to validate inheritance fields directly.
Currently I added some most used special fields as separate fields to make IDEs/editors happy. Although they are not complete, it doesn't break the validator because the validator will remove all special suffixes before validate `releases.yml`.