### PR TITLE
Do not validate releases.yml on every run

### DIFF
--- a/validator/__main__.py
+++ b/validator/__main__.py
@@ -25,13 +25,6 @@ def validate(file):
         msg = 'Schema mismatch: {}\nReturned error: {}'.format(file, err)
         support.fail_validation(msg, parsed)
 
-    releases_cfg = support.load_releases_config_for(file)
-    if releases_cfg:
-        err = releases_schema.validate(file, releases_cfg)
-        if err:
-            msg = '\nSchema failure for releases.yml\nReturned error: {}\n\n'.format(err)
-            support.fail_validation(msg, parsed)
-
     if support.get_artifact_type(file) not in ['image', 'rpm']:
         return
 

--- a/validator/__main__.py
+++ b/validator/__main__.py
@@ -5,7 +5,6 @@ from multiprocessing import Pool, cpu_count
 
 from . import format, support, schema, github, distgit, cgit
 from . import exceptions, global_session
-from validator.schema import releases_schema
 
 
 def validate(file):

--- a/validator/__main__.py
+++ b/validator/__main__.py
@@ -8,8 +8,6 @@ from . import exceptions, global_session
 
 
 def validate(file):
-    print('Validating {}'.format(file))
-
     (parsed, err) = format.validate(open(file).read())
     if err:
         msg = '{} is not a valid YAML\nReturned error: {}'.format(file, err)
@@ -47,6 +45,8 @@ def validate(file):
                'Returned error: {}').format(file, url, err)
         support.fail_validation(msg, parsed)
 
+    print(f'✅ Validated {file}')
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -63,7 +63,7 @@ def main():
                         action='store_true',
                         help='Run in single thread, so code.interact() works')
     args = parser.parse_args()
-
+    print(f"Validating {len(args.files)} file(s)...")
     if args.single_thread:
         for f in args.files:
             validate(f)

--- a/validator/schema/__init__.py
+++ b/validator/schema/__init__.py
@@ -1,4 +1,4 @@
-from . import image_schema, rpm_schema, streams_schema
+from . import image_schema, rpm_schema, streams_schema, releases_schema
 from .. import support
 
 
@@ -13,6 +13,7 @@ def validate(file, data):
         'image': image_schema.validate,
         'rpm': rpm_schema.validate,
         'ignore': ignore_validate,
+        'releases': releases_schema.validate
     }.get(support.get_artifact_type(file), err)(file, data)
 
 

--- a/validator/schema/releases_schema.py
+++ b/validator/schema/releases_schema.py
@@ -26,112 +26,111 @@ ARCHES_DICT = {
 }
 
 
-def releases_schema(file):
-    return Schema({
-        'releases': {
-            Optional(Or('stream', 'test', ASSEMBLY_NAME_REGEX)): {
-                'assembly': {
-                    Optional('type'): Or('standard', 'custom', 'candidate', 'stream'),
-                    Optional('basis'): {
-                        Optional('brew_event'): int,
-                        Optional('assembly'): ASSEMBLY_NAME_REGEX,
+releases_schema = Schema({
+    'releases': {
+        Optional(Or('stream', 'test', ASSEMBLY_NAME_REGEX)): {
+            'assembly': {
+                Optional('type'): Or('standard', 'custom', 'candidate', 'stream'),
+                Optional('basis'): {
+                    Optional('brew_event'): int,
+                    Optional('assembly'): ASSEMBLY_NAME_REGEX,
 
-                        # If specified, when generating a release payload, "oc adm release new" will be run with from-release.
-                        # However, the basis brew_event is still king and all images found in the nightlies
-                        # must align perfectly with the basis & machine-os-content images of the assembly
-                        # or an error will be thrown. Why? Nightly records can be lost. We need to be able to
-                        # reconstruct from a source of truth.
-                        # If not specified, oc release new will not be passed from-release.
-                        Optional('reference_releases'): ARCHES_DICT,  # per-arch nightly names
+                    # If specified, when generating a release payload, "oc adm release new" will be run with from-release.
+                    # However, the basis brew_event is still king and all images found in the nightlies
+                    # must align perfectly with the basis & machine-os-content images of the assembly
+                    # or an error will be thrown. Why? Nightly records can be lost. We need to be able to
+                    # reconstruct from a source of truth.
+                    # If not specified, oc release new will not be passed from-release.
+                    Optional('reference_releases'): ARCHES_DICT,  # per-arch nightly names
+                },
+                Optional('permits'): [  # A list of issues that this assembly permits during payload generation.
+                    And({
+                        'code': Regex('[A-Z0-9_]+'),
+                        'component': str,  # A component name or '*'
+                    })
+                ],
+                Optional('promotion_permits'): [  # A list of issues that this assembly permits during payload promotion.
+                    And({
+                        'code': Regex('[A-Z0-9_]+'),
+                        'why': str,  # A component name or '*'
+                    })
+                ],
+                Optional('rhcos'): {
+                    'machine-os-content': {
+                        'images': ARCHES_DICT,  # pullspecs for arch specific images
                     },
-                    Optional('permits'): [  # A list of issues that this assembly permits during payload generation.
-                        And({
-                            'code': Regex('[A-Z0-9_]+'),
-                            'component': str,  # A component name or '*'
-                        })
-                    ],
-                    Optional('promotion_permits'): [  # A list of issues that this assembly permits during payload promotion.
-                        And({
-                            'code': Regex('[A-Z0-9_]+'),
-                            'why': str,  # A component name or '*'
-                        })
-                    ],
-                    Optional('rhcos'): {
-                        'machine-os-content': {
-                            'images': ARCHES_DICT,  # pullspecs for arch specific images
-                        },
-                        Optional('dependencies'): ASSEMBLY_DEPENDENCIES,
-                    },
-                    Optional('streams'): STREAMS_SCHEMA,
-                    Optional('group'): {
-                        Optional('arches'): [ARCHES],
-                        Optional('repos'): {
-                            Regex('[a-z0-9.-]+'): {
-                                'conf': {
-                                    'baseurl': {
-                                        ARCHES: str,
-                                    }
+                    Optional('dependencies'): ASSEMBLY_DEPENDENCIES,
+                },
+                Optional('streams'): STREAMS_SCHEMA,
+                Optional('group'): {
+                    Optional('arches'): [ARCHES],
+                    Optional('repos'): {
+                        Regex('[a-z0-9.-]+'): {
+                            'conf': {
+                                'baseurl': {
+                                    ARCHES: str,
                                 }
                             }
-                        },
-                        Optional('advisories'): {
-                            Optional('image'): int,
-                            Optional('rpm'): int,
-                            Optional('extras'): int,
-                            Optional('metadata'): int,
-                        },
-                        Optional('dependencies'): ASSEMBLY_DEPENDENCIES,
-                        Optional('release_jira'): str,
-                        Optional('upgrades'): Regex(UPGRADE_EDGES_REGEX),
-                        Optional('cachito'): {
-                            Optional('enabled'): bool,
-                            Optional('flags'): [str],
-                        },
+                        }
                     },
-                    Optional('members'): {
-                        Optional('rpms'): [
-                            And({
-                                'distgit_key': str,
-                                'why': str,  # Human description of why this is being added for historical purposes
-                                Optional('metadata'): {
-                                    Optional('content'): RPM_CONTENT_SCHEMA,
-                                    Optional('is'): {
-                                        Regex(r'el\d+'): str
-                                    }
-                                },
-                            })
-                        ],
-                        Optional('images'): [
-                            And({
-                                'distgit_key': str,
-                                'why': str,  # Human description of why this is being added for historical purposes
-                                Optional('metadata'): {
-                                    Optional('container_yaml'): object,
-                                    Optional('content'): IMAGE_CONTENT_SCHEMA,
-                                    Optional('dependencies'): ASSEMBLY_DEPENDENCIES,
-                                    Optional('is'): {
-                                        'nvr': str
-                                    },
-                                },
-                            })
-                        ]
+                    Optional('advisories'): {
+                        Optional('image'): int,
+                        Optional('rpm'): int,
+                        Optional('extras'): int,
+                        Optional('metadata'): int,
                     },
-                    Optional('issues'): {
-                        Optional('include'): [
-                            And({
-                                'id': Or(int, Regex(r'[A-Z]+-\d+'))  # bugzilla or Jira
-                            })
-                        ],
-                        Optional('exclude'): [
-                            And({
-                                'id': Or(int, Regex(r'[A-Z]+-\d+'))  # bugzilla or Jira
-                            })
-                        ],
+                    Optional('dependencies'): ASSEMBLY_DEPENDENCIES,
+                    Optional('release_jira'): str,
+                    Optional('upgrades'): Regex(UPGRADE_EDGES_REGEX),
+                    Optional('cachito'): {
+                        Optional('enabled'): bool,
+                        Optional('flags'): [str],
                     },
                 },
-            }
+                Optional('members'): {
+                    Optional('rpms'): [
+                        And({
+                            'distgit_key': str,
+                            'why': str,  # Human description of why this is being added for historical purposes
+                            Optional('metadata'): {
+                                Optional('content'): RPM_CONTENT_SCHEMA,
+                                Optional('is'): {
+                                    Regex(r'el\d+'): str
+                                }
+                            },
+                        })
+                    ],
+                    Optional('images'): [
+                        And({
+                            'distgit_key': str,
+                            'why': str,  # Human description of why this is being added for historical purposes
+                            Optional('metadata'): {
+                                Optional('container_yaml'): object,
+                                Optional('content'): IMAGE_CONTENT_SCHEMA,
+                                Optional('dependencies'): ASSEMBLY_DEPENDENCIES,
+                                Optional('is'): {
+                                    'nvr': str
+                                },
+                            },
+                        })
+                    ]
+                },
+                Optional('issues'): {
+                    Optional('include'): [
+                        And({
+                            'id': Or(int, Regex(r'[A-Z]+-\d+'))  # bugzilla or Jira
+                        })
+                    ],
+                    Optional('exclude'): [
+                        And({
+                            'id': Or(int, Regex(r'[A-Z]+-\d+'))  # bugzilla or Jira
+                        })
+                    ],
+                },
+            },
         }
-    })
+    }
+})
 
 
 def _demerge(data):
@@ -158,8 +157,8 @@ def _demerge(data):
     raise TypeError(f"Unexpected value type: {type(data)}: {data}")
 
 
-def validate(file, data):
+def validate(_, data):
     try:
-        releases_schema(file).validate(_demerge(data))
+        releases_schema.validate(_demerge(data))
     except SchemaError as err:
         return '{}'.format(err)

--- a/validator/support.py
+++ b/validator/support.py
@@ -21,13 +21,6 @@ def load_group_config_for(file):
     return YAML(typ='safe').load(open(group_yaml).read())
 
 
-def load_releases_config_for(file):
-    releases_yaml = os.path.join(get_ocp_build_data_dir(file), 'releases.yml')
-    if not os.path.exists(releases_yaml):
-        return None
-    return releases_yaml
-
-
 def get_ocp_build_data_dir(file):
     file_path = os.path.dirname(file)
     if os.path.exists(os.path.join(file_path, 'group.yml')):

--- a/validator/support.py
+++ b/validator/support.py
@@ -25,7 +25,7 @@ def load_releases_config_for(file):
     releases_yaml = os.path.join(get_ocp_build_data_dir(file), 'releases.yml')
     if not os.path.exists(releases_yaml):
         return None
-    return YAML(typ='safe').load(open(releases_yaml).read())
+    return releases_yaml
 
 
 def get_ocp_build_data_dir(file):
@@ -40,7 +40,10 @@ def get_ocp_build_data_dir(file):
 
 
 def get_artifact_type(file):
-    if file == 'streams.yml':
+    if 'releases.yml' in file:
+        return 'releases'
+
+    if 'streams.yml' in file:
         return 'streams'
 
     if 'images/' in file:
@@ -49,7 +52,7 @@ def get_artifact_type(file):
     if 'rpms/' in file:
         return 'rpm'
 
-    if any([x in file for x in ['releases.yml', 'erratatool.yml', 'group.yml', 'bugzilla.yml']]):
+    if any([x in file for x in ['erratatool.yml', 'group.yml', 'bugzilla.yml']]):
         return 'ignore'
 
     return '???'


### PR DESCRIPTION
Right now we validate releases.yml - when validating any file. Since our releases.yml 
gets updated very frequently, with new keys added and not every key is added to 
schema or with some non-critical invalid entry, it results in validation fail.
That results in early exit of ocp-build-data-validator command where validation result 
for other files isn't run/displayed - [like this](https://coreos.slack.com/archives/GDBRP5YJH/p1646950803184889?thread_ts=1646927201.739019&cid=GDBRP5YJH)
So let's validate releases.yml only when it's requested (when a PR changes it).

I refactored releases validation as to how we validate other files with specific schema.

I updated the messaging a bit to avoid confusion as to what has been validated.
example see this - https://github.com/openshift/ocp-build-data/pull/1393#issuecomment-1064475733 (confusing as to what exactly was validated..)
Since our ci run is one single command with multiple files - 
- print one top level processing message
- then individual success messages
