### PR TITLE
use lower version to meet the build requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ idna==2.9
 importlib-metadata==1.6.1
 importlib-resources==1.5.0
 jeepney==0.4.3
-jsonschema ~= 4.4.0
+jsonschema ~= 4.0.0
 keyring==21.2.1
 packaging==20.4
 pkginfo==1.5.0.1


### PR DESCRIPTION
build log shows it need a lower version
https://console-openshift-console.apps.art.xq1c.p1.openshiftapps.com/k8s/ns/art-tools/builds/ocp-build-data-validator-update-58/logs