### PR TITLE
Use JSON schema to validate image configs

### DIFF
--- a/SETUP_EDITOR.md
+++ b/SETUP_EDITOR.md
@@ -8,10 +8,11 @@
     {
         "yaml.schemas": {
             "/path/to/json_schemas/releases.schema.json": "/releases.yml",
+            "/path/to/json_schemas/image_config.schema.json": "/images/*.yml",
         }
     }
     ```
-- Open `releases.yml`.
+- Open the .yml file that you want to edit.
 
 ## PyCharm (or other Intellij IDEA based IDEs)
 - Open `ocp-build-data` project.
@@ -39,10 +40,11 @@
   {
         "yaml.schemas": {
             "/path/to/json_schemas/releases.schema.json": "/releases.yml",
+            "/path/to/json_schemas/image_config.schema.json": "/images/*.yml",
         }
   }
   ```
-- End editing configuration and open `releases.yaml`.
+- Open the .yml file that you want to edit.
 
 
 [1]: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -13,7 +13,7 @@ class TestFormat(unittest.TestCase):
         """
         (parsed, err) = format.validate(invalid_yaml)
         self.assertIsNone(parsed)
-        self.assertEqual(True, "did not find expected key" in err)
+        self.assertIn("did not find expected key", err)
 
     def test_valid_yaml(self):
         valid_yaml = """

--- a/tests/test_schema/test_image_schema.py
+++ b/tests/test_schema/test_image_schema.py
@@ -1,20 +1,9 @@
 import unittest
-from flexmock import flexmock
 
 from validator.schema import image_schema
 
 
 class TestImageSchema(unittest.TestCase):
-
-    def setUp(self):
-        (flexmock(image_schema.support)
-            .should_receive('get_valid_streams_for')
-            .and_return([]))
-
-        (flexmock(image_schema.support)
-            .should_receive('get_valid_member_references_for')
-            .and_return([]))
-
     def test_validate_with_valid_data(self):
         valid_data = {
             'from': {},
@@ -28,8 +17,8 @@ class TestImageSchema(unittest.TestCase):
             'from': {},
             'name': 1234,
         }
-        self.assertEqual("Key 'name' error:\n1234 should be instance of 'str'",
-                         image_schema.validate('filename', invalid_data))
+        self.assertIn("1234 is not of type 'string'",
+                      image_schema.validate('filename', invalid_data))
 
     def test_validate_with_invalid_content_source_git_url(self):
         url = 'https://github.com/openshift/csi-node-driver-registrar'
@@ -47,7 +36,7 @@ class TestImageSchema(unittest.TestCase):
             'name': '1234',
             'from': {},
         }
-        self.assertIn("Key 'content' error:\nKey", image_schema.validate('filename', invalid_data))
+        self.assertIn("'https://github.com/openshift/csi-node-driver-registrar' does not match", image_schema.validate('filename', invalid_data))
 
     def test_validate_with_valid_content_source_git_url(self):
         url = 'git@github.com:openshift/csi-node-driver-registrar.git'
@@ -94,6 +83,6 @@ class TestImageSchema(unittest.TestCase):
             },
         }
         self.assertIn(
-            "Missing key: 'valid-subscription-label'",
+            "Failed validating 'anyOf' in schema",
             image_schema.validate('filename', data)
         )

--- a/validator/__main__.py
+++ b/validator/__main__.py
@@ -82,3 +82,7 @@ def main():
 
         finally:
             exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/validator/json_schemas/arch.schema.json
+++ b/validator/json_schemas/arch.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "arch.schema.json",
+  "title": "Architecture",
+  "type": "string",
+  "enum": ["x86_64", "s390x", "ppc64le", "aarch64"]
+}

--- a/validator/json_schemas/arches.schema.json
+++ b/validator/json_schemas/arches.schema.json
@@ -1,8 +1,0 @@
-{
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "array",
-    "items": {
-        "type": "string",
-        "enum": ["x86_64", "s390x", "ppc64le", "aarch64"]
-    }
-}

--- a/validator/json_schemas/arches_dict.schema.json
+++ b/validator/json_schemas/arches_dict.schema.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "arches_dict.schema.json",
+  "title": "Architectures Dict",
   "type": "object",
   "properties": {
     "x86_64": {

--- a/validator/json_schemas/assembly.schema.json
+++ b/validator/json_schemas/assembly.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "assembly.schema.json",
   "title": "Assembly",
   "description": "An assembly represents unambiguous, programmatic instructions on how to build and rebuild a release payload at any point in the future.",
   "type": "object",

--- a/validator/json_schemas/assembly_basis.schema.json
+++ b/validator/json_schemas/assembly_basis.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Basis of the assembly",
+  "$id": "assembly_basis.schema.json",
+  "title": "Assembly Basis",
   "description": "Basis ties the release to a particular moment, existing release, or another release.",
   "type": "object",
   "properties": {
@@ -15,6 +16,7 @@
       "minLength": 1
     },
     "reference_releases": {
+      "title": "Reference releases",
       "description": "Indicates this release should be assembled with specified existing release images",
       "$ref": "arches_dict.schema.json"
     },

--- a/validator/json_schemas/assembly_dependencies.schema.json
+++ b/validator/json_schemas/assembly_dependencies.schema.json
@@ -1,8 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "assembly_dependencies.schema.json",
+  "title": "Assembly Dependencies",
   "type": "object",
   "properties": {
     "rpms": {
+      "title": "RPM dependencies",
       "type": "array",
       "items": {
         "type": "object",

--- a/validator/json_schemas/assembly_group_config.schema.json
+++ b/validator/json_schemas/assembly_group_config.schema.json
@@ -1,9 +1,14 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "assembly_group_config.schema.json",
+  "title": "Assembly Group Configuration",
   "type": "object",
   "properties": {
     "arches": {
-      "$ref": "arches.schema.json"
+      "type": "array",
+      "items": {
+        "$ref": "arch.schema.json"
+      }
     },
     "arches!": {
       "$ref": "#/properties/arches"

--- a/validator/json_schemas/assembly_issues.schema.json
+++ b/validator/json_schemas/assembly_issues.schema.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "assembly_issues.schema.json",
+  "title": "Assembly Issues",
   "type": "object",
   "properties": {
     "include": {

--- a/validator/json_schemas/cachito.schema.json
+++ b/validator/json_schemas/cachito.schema.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "cachito.schema.json",
+  "title": "Cachito",
   "type": "object",
   "description": "Cachito integration configuration",
   "properties": {
@@ -9,6 +11,7 @@
     },
     "enabled-": {},
     "flags": {
+      "description": "Configure Cachito flags. See https://github.com/containerbuildsystem/cachito#flags",
       "type": "array",
       "items": {
         "type": "string",
@@ -21,7 +24,86 @@
     "flags?": {
       "$ref": "#/properties/flags"
     },
-    "flags-": {}
+    "flags-": {},
+    "packages": {
+      "description": "Allow user to customize `packages` option for Cachito configuration. See https://osbs.readthedocs.io/en/osbs_ocp3/users.html#remote-source-keys",
+      "type": "object",
+      "properties": {
+        "gomod": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "gomod!": {
+          "$ref": "#/properties/packages/properties/gomod"
+        },
+        "gomod?": {
+          "$ref": "#/properties/packages/properties/gomod"
+        },
+        "gomod-": {},
+        "pip": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "pip!": {
+          "$ref": "#/properties/packages/properties/pip"
+        },
+        "pip?": {
+          "$ref": "#/properties/packages/properties/pip"
+        },
+        "pip-": {},
+        "npm": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "npm!": {
+          "$ref": "#/properties/packages/properties/npm"
+        },
+        "npm?": {
+          "$ref": "#/properties/packages/properties/npm"
+        },
+        "npm-": {},
+        "yarn": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "yarn!": {
+          "$ref": "#/properties/packages/properties/yarn"
+        },
+        "yarn?": {
+          "$ref": "#/properties/packages/properties/yarn"
+        },
+        "yarn-": {},
+        "git-submodule": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "git-submodule!": {
+          "$ref": "#/properties/packages/properties/git-submodule"
+        },
+        "git-submodule?": {
+          "$ref": "#/properties/packages/properties/git-submodule"
+        },
+        "git-submodule-": {}
+      },
+      "additionalProperties": false
+    },
+    "packages!": {
+      "$ref": "#/properties/packages"
+    },
+    "packages?": {
+      "$ref": "#/properties/packages"
+    },
+    "packages-": {}
   },
   "additionalProperties": false
 }

--- a/validator/json_schemas/image_config.base.schema.json
+++ b/validator/json_schemas/image_config.base.schema.json
@@ -1,0 +1,856 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "image_config.base.schema.json",
+  "title": "Image Configuration",
+  "type": "object",
+  "properties": {
+    "additional_tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "additional_tags!": {
+      "$ref": "#/properties/additional_tags"
+    },
+    "additional_tags?": {
+      "$ref": "#/properties/additional_tags"
+    },
+    "additional_tags-": {},
+    "arches": {
+      "type": "array",
+      "items": {
+        "$ref": "arch.schema.json"
+      }
+    },
+    "arches!": {
+      "$ref": "#/properties/arches"
+    },
+    "arches?": {
+      "$ref": "#/properties/arches"
+    },
+    "arches-": {},
+    "base_only": {
+      "type": "boolean"
+    },
+    "base_only!": {
+      "$ref": "#/properties/base_only"
+    },
+    "base_only?": {
+      "$ref": "#/properties/base_only"
+    },
+    "base_only-": {},
+    "cachito": {
+      "description": "Cachito integration configuration",
+      "$ref": "cachito.schema.json"
+    },
+    "cachito!": {
+      "$ref": "#/properties/cachito"
+    },
+    "cachito?": {
+      "$ref": "#/properties/cachito"
+    },
+    "cachito-": {},
+    "container_yaml": {
+      "type": "object"
+    },
+    "container_yaml!": {
+      "$ref": "#/properties/container_yaml"
+    },
+    "container_yaml?": {
+      "$ref": "#/properties/container_yaml"
+    },
+    "container_yaml-": {},
+    "content": {
+      "description": "Image content configuration",
+      "$ref": "image_content.base.schema.json"
+    },
+    "content!": {
+      "$ref": "#/properties/content"
+    },
+    "content?": {
+      "$ref": "#/properties/content"
+    },
+    "content-": {},
+    "dependencies": {
+      "$ref": "assembly_dependencies.schema.json"
+    },
+    "dependencies!": {
+      "$ref": "#/properties/dependencies"
+    },
+    "dependencies?": {
+      "$ref": "#/properties/dependencies"
+    },
+    "dependencies-": {},
+    "dependents": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "dependents!": {
+      "$ref": "#/properties/dependents"
+    },
+    "dependents?": {
+      "$ref": "#/properties/dependents"
+    },
+    "dependents-": {},
+    "distgit": {
+      "type": "object",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "enum": [
+            "apbs",
+            "containers",
+            "rpms"
+          ]
+        },
+        "namespace!": {
+          "$ref": "#/properties/distgit/properties/namespace"
+        },
+        "namespace?": {
+          "$ref": "#/properties/distgit/properties/namespace"
+        },
+        "namespace-": {},
+        "component": {
+          "type": "string",
+          "minLength": 1
+        },
+        "component!": {
+          "$ref": "#/properties/distgit/properties/component"
+        },
+        "component?": {
+          "$ref": "#/properties/distgit/properties/component"
+        },
+        "component-": {},
+        "bundle_component": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bundle_component!": {
+          "$ref": "#/properties/distgit/properties/bundle_component"
+        },
+        "bundle_component?": {
+          "$ref": "#/properties/distgit/properties/bundle_component"
+        },
+        "bundle_component-": {},
+        "branch": {
+          "type": "string",
+          "minLength": 1
+        },
+        "branch!": {
+          "$ref": "#/properties/distgit/properties/branch"
+        },
+        "branch?": {
+          "$ref": "#/properties/distgit/properties/branch"
+        },
+        "branch-": {}
+      },
+      "additionalProperties": false
+    },
+    "distgit!": {
+      "$ref": "#/properties/distgit"
+    },
+    "distgit?": {
+      "$ref": "#/properties/distgit"
+    },
+    "distgit-": {},
+    "final_stage_user": {
+      "description": "When doozer injects USER 0 to do a yum update, this field instructs doozer to set this user afterwards in the final stage of the build.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "final_stage_user!": {
+      "$ref": "#/properties/final_stage_user"
+    },
+    "final_stage_user?": {
+      "$ref": "#/properties/final_stage_user"
+    },
+    "final_stage_user-": {},
+    "enabled_repos": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "enabled_repos!": {
+      "$ref": "#/properties/enabled_repos"
+    },
+    "enabled_repos?": {
+      "$ref": "#/properties/enabled_repos"
+    },
+    "enabled_repos-": {},
+    "non_shipping_repos": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "non_shipping_repos!": {
+      "$ref": "#/properties/non_shipping_repos"
+    },
+    "non_shipping_repos?": {
+      "$ref": "#/properties/non_shipping_repos"
+    },
+    "non_shipping_repos-": {},
+    "non_shipping_rpms": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "non_shipping_rpms!": {
+      "$ref": "#/properties/non_shipping_rpms"
+    },
+    "non_shipping_rpms?": {
+      "$ref": "#/properties/non_shipping_rpms"
+    },
+    "non_shipping_rpms-": {},
+    "from": {
+      "type": "object",
+      "properties": {
+        "builder": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "stream": {
+                "type": "string",
+                "minLength": 1
+              },
+              "stream!": {
+                "$ref": "#/properties/from/properties/builder/items/properties/stream"
+              },
+              "stream?": {
+                "$ref": "#/properties/from/properties/builder/items/properties/stream"
+              },
+              "stream-": {},
+              "member": {
+                "type": "string",
+                "minLength": 1
+              },
+              "member!": {
+                "$ref": "#/properties/from/properties/builder/items/properties/member"
+              },
+              "member?": {
+                "$ref": "#/properties/from/properties/builder/items/properties/member"
+              },
+              "member-": {},
+              "image": {
+                "type": "string",
+                "minLength": 1
+              },
+              "image!": {
+                "$ref": "#/properties/from/properties/builder/items/properties/image"
+              },
+              "image?": {
+                "$ref": "#/properties/from/properties/builder/items/properties/image"
+              },
+              "image-": {}
+            }
+          }
+        },
+        "stream": {
+          "type": "string",
+          "minLength": 1
+        },
+        "stream!": {
+          "$ref": "#/properties/from/properties/stream"
+        },
+        "stream?": {
+          "$ref": "#/properties/from/properties/stream"
+        },
+        "stream-": {},
+        "member": {
+          "type": "string",
+          "minLength": 1
+        },
+        "member!": {
+          "$ref": "#/properties/from/properties/member"
+        },
+        "member?": {
+          "$ref": "#/properties/from/properties/member"
+        },
+        "member-": {},
+        "image": {
+          "type": "string",
+          "minLength": 1
+        },
+        "image!": {
+          "$ref": "#/properties/from/properties/image"
+        },
+        "image?": {
+          "$ref": "#/properties/from/properties/image"
+        },
+        "image-": {}
+      },
+      "additionalProperties": false
+    },
+    "from!": {
+      "$ref": "#/properties/from"
+    },
+    "from?": {
+      "$ref": "#/properties/from"
+    },
+    "from-": {},
+    "labels": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "summary!": {
+          "$ref": "#/properties/labels/properties/summary"
+        },
+        "summary?": {
+          "$ref": "#/properties/labels/properties/summary"
+        },
+        "summary-": {},
+        "License": {
+          "type": "string",
+          "minLength": 1
+        },
+        "License!": {
+          "$ref": "#/properties/labels/properties/License"
+        },
+        "License?": {
+          "$ref": "#/properties/labels/properties/License"
+        },
+        "License-": {},
+        "com.redhat.delivery.appregistry": {
+          "oneOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "boolean"
+            }
+          ]
+        },
+        "com.redhat.delivery.appregistry!": {
+          "$ref": "#/properties/labels/properties/com.redhat.delivery.appregistry"
+        },
+        "com.redhat.delivery.appregistry?": {
+          "$ref": "#/properties/labels/properties/com.redhat.delivery.appregistry"
+        },
+        "com.redhat.delivery.appregistry-": {},
+        "io.k8s.description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "io.k8s.description!": {
+          "$ref": "#/properties/labels/properties/io.k8s.description"
+        },
+        "io.k8s.description?": {
+          "$ref": "#/properties/labels/properties/io.k8s.description"
+        },
+        "io.k8s.description-": {},
+        "io.k8s.display-name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "io.k8s.display-name!": {
+          "$ref": "#/properties/labels/properties/io.k8s.display-name"
+        },
+        "io.k8s.display-name?": {
+          "$ref": "#/properties/labels/properties/io.k8s.display-name"
+        },
+        "io.k8s.display-name-": {},
+        "io.openshift.release.operator": {
+          "type": "string",
+          "minLength": 1
+        },
+        "io.openshift.release.operator!": {
+          "$ref": "#/properties/labels/properties/io.openshift.release.operator"
+        },
+        "io.openshift.release.operator?": {
+          "$ref": "#/properties/labels/properties/io.openshift.release.operator"
+        },
+        "io.openshift.release.operator-": {},
+        "io.openshift.tags": {
+          "type": "string",
+          "minLength": 1
+        },
+        "io.openshift.tags!": {
+          "$ref": "#/properties/labels/properties/io.openshift.tags"
+        },
+        "io.openshift.tags?": {
+          "$ref": "#/properties/labels/properties/io.openshift.tags"
+        },
+        "io.openshift.tags-": {},
+        "vendor": {
+          "type": "string",
+          "minLength": 1
+        },
+        "vendor!": {
+          "$ref": "#/properties/labels/properties/vendor"
+        },
+        "vendor?": {
+          "$ref": "#/properties/labels/properties/vendor"
+        },
+        "vendor-": {}
+      },
+      "additionalProperties": false
+    },
+    "labels!": {
+      "$ref": "#/properties/labels"
+    },
+    "labels?": {
+      "$ref": "#/properties/labels"
+    },
+    "labels-": {},
+    "image_build_method": {
+      "type": "string",
+      "minLength": 1
+    },
+    "image_build_method!": {
+      "$ref": "#/properties/image_build_method"
+    },
+    "image_build_method?": {
+      "$ref": "#/properties/image_build_method"
+    },
+    "image_build_method-": {},
+    "mode": {
+      "type": "string",
+      "enum": [
+        "auto",
+        "disabled",
+        "wip"
+      ]
+    },
+    "mode!": {
+      "$ref": "#/properties/mode"
+    },
+    "mode?": {
+      "$ref": "#/properties/mode"
+    },
+    "mode-": {},
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "name!": {
+      "$ref": "#/properties/name"
+    },
+    "name?": {
+      "$ref": "#/properties/name"
+    },
+    "name-": {},
+    "odcs": {
+      "type": "object",
+      "properties": {
+        "packages": {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": [
+                "auto",
+                "manual"
+              ]
+            },
+            "mode!": {
+              "$ref": "#/properties/odcs/properties/packages/properties/mode"
+            },
+            "mode?": {
+              "$ref": "#/properties/odcs/properties/packages/properties/mode"
+            },
+            "mode-": {},
+            "list": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "list!": {
+              "$ref": "#/properties/odcs/properties/packages/properties/list"
+            },
+            "list?": {
+              "$ref": "#/properties/odcs/properties/packages/properties/list"
+            },
+            "list-": {},
+            "exclude": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "exclude!": {
+              "$ref": "#/properties/odcs/properties/packages/properties/exclude"
+            },
+            "exclude?": {
+              "$ref": "#/properties/odcs/properties/packages/properties/exclude"
+            },
+            "exclude-": {}
+          },
+          "additionalProperties": false
+        },
+        "packages!": {
+          "$ref": "#/properties/odcs/properties/packages"
+        },
+        "packages?": {
+          "$ref": "#/properties/odcs/properties/packages"
+        },
+        "packages-": {}
+      },
+      "additionalProperties": false
+    },
+    "odcs!": {
+      "$ref": "#/properties/odcs"
+    },
+    "odcs?": {
+      "$ref": "#/properties/odcs"
+    },
+    "odcs-": {},
+    "no_oit_comments": {
+      "type": "boolean"
+    },
+    "no_oit_comments!": {
+      "$ref": "#/properties/no_oit_comments"
+    },
+    "no_oit_comments?": {
+      "$ref": "#/properties/no_oit_comments"
+    },
+    "no_oit_comments-": {},
+    "owners": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "owners!": {
+      "$ref": "#/properties/owners"
+    },
+    "owners?": {
+      "$ref": "#/properties/owners"
+    },
+    "owners-": {},
+    "payload_name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "payload_name!": {
+      "$ref": "#/properties/payload_name"
+    },
+    "payload_name?": {
+      "$ref": "#/properties/payload_name"
+    },
+    "payload_name-": {},
+    "push": {
+      "type": "object",
+      "properties": {
+        "late": {
+          "type": "boolean"
+        },
+        "late!": {
+          "$ref": "#/properties/push/properties/late"
+        },
+        "late?": {
+          "$ref": "#/properties/push/properties/late"
+        },
+        "late-": {},
+        "repos": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "repos!": {
+          "$ref": "#/properties/push/properties/repos"
+        },
+        "repos?": {
+          "$ref": "#/properties/push/properties/repos"
+        },
+        "repos-": {},
+        "additional_tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "additional_tags!": {
+          "$ref": "#/properties/push/properties/additional_tags"
+        },
+        "additional_tags?": {
+          "$ref": "#/properties/push/properties/additional_tags"
+        },
+        "additional_tags-": {}
+      },
+      "additionalProperties": false
+    },
+    "push!": {
+      "$ref": "#/properties/push"
+    },
+    "push?": {
+      "$ref": "#/properties/push"
+    },
+    "push-": {},
+    "required": {
+      "type": "boolean"
+    },
+    "required!": {
+      "$ref": "#/properties/required"
+    },
+    "required?": {
+      "$ref": "#/properties/required"
+    },
+    "required-": {},
+    "scan_sources": {
+      "type": "object",
+      "properties": {
+        "extra_packages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "name!": {
+                "$ref": "#/properties/scan_sources/properties/extra_packages/items/properties/name"
+              },
+              "name?": {
+                "$ref": "#/properties/scan_sources/properties/extra_packages/items/properties/name"
+              },
+              "name-": {},
+              "tag": {
+                "type": "string",
+                "minLength": 1
+              },
+              "tag!": {
+                "$ref": "#/properties/scan_sources/properties/extra_packages/items/properties/tag"
+              },
+              "tag?": {
+                "$ref": "#/properties/scan_sources/properties/extra_packages/items/properties/tag"
+              },
+              "tag-": {}
+            }
+          }
+        },
+        "extra_packages!": {
+          "$ref": "#/properties/scan_sources/properties/extra_packages"
+        },
+        "extra_packages?": {
+          "$ref": "#/properties/scan_sources/properties/extra_packages"
+        },
+        "extra_packages-": {}
+      },
+      "additionalProperties": false
+    },
+    "scan_sources!": {
+      "$ref": "#/properties/scan_sources"
+    },
+    "scan_sources?": {
+      "$ref": "#/properties/scan_sources"
+    },
+    "scan_sources-": {},
+    "update-csv": {
+      "type": "object",
+      "properties": {
+        "manifests-dir": {
+          "type": "string",
+          "minLength": 1
+        },
+        "manifests-dir!": {
+          "$ref": "#/properties/update-csv/properties/manifests-dir"
+        },
+        "manifests-dir?": {
+          "$ref": "#/properties/update-csv/properties/manifests-dir"
+        },
+        "manifests-dir-": {},
+        "bundle-dir": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bundle-dir!": {
+          "$ref": "#/properties/update-csv/properties/bundle-dir"
+        },
+        "bundle-dir?": {
+          "$ref": "#/properties/update-csv/properties/bundle-dir"
+        },
+        "bundle-dir-": {},
+        "registry": {
+          "type": "string",
+          "minLength": 1
+        },
+        "registry!": {
+          "$ref": "#/properties/update-csv/properties/registry"
+        },
+        "registry?": {
+          "$ref": "#/properties/update-csv/properties/registry"
+        },
+        "registry-": {},
+        "valid-subscription-label": {
+          "type": "string",
+          "minLength": 1
+        },
+        "valid-subscription-label!": {
+          "$ref": "#/properties/update-csv/properties/valid-subscription-label"
+        },
+        "valid-subscription-label?": {
+          "$ref": "#/properties/update-csv/properties/valid-subscription-label"
+        },
+        "valid-subscription-label-": {},
+        "channel": {
+          "type": "string",
+          "minLength": 1
+        },
+        "channel!": {
+          "$ref": "#/properties/update-csv/properties/channel"
+        },
+        "channel?": {
+          "$ref": "#/properties/update-csv/properties/channel"
+        },
+        "channel-": {},
+        "image-map": {
+          "type": "object"
+        },
+        "image-map!": {
+          "$ref": "#/properties/update-csv/properties/image-map"
+        },
+        "image-map?": {
+          "$ref": "#/properties/update-csv/properties/image-map"
+        },
+        "image-map-": {}
+      },
+      "additionalProperties": false
+    },
+    "update-csv!": {
+      "$ref": "#/properties/update-csv"
+    },
+    "update-csv?": {
+      "$ref": "#/properties/update-csv"
+    },
+    "update-csv-": {},
+    "wait_for": {
+      "type": "string",
+      "minLength": 1
+    },
+    "wait_for!": {
+      "$ref": "#/properties/wait_for"
+    },
+    "wait_for?": {
+      "$ref": "#/properties/wait_for"
+    },
+    "wait_for-": {},
+    "maintainer": {
+      "type": "object",
+      "properties": {
+        "product": {
+          "type": "string",
+          "minLength": 1
+        },
+        "product!": {
+          "$ref": "#/properties/maintainer/properties/product"
+        },
+        "product?": {
+          "$ref": "#/properties/maintainer/properties/product"
+        },
+        "product-": {},
+        "component": {
+          "type": "string",
+          "minLength": 1
+        },
+        "component!": {
+          "$ref": "#/properties/maintainer/properties/component"
+        },
+        "component?": {
+          "$ref": "#/properties/maintainer/properties/component"
+        },
+        "component-": {},
+        "subcomponent": {
+          "type": "string",
+          "minLength": 1
+        },
+        "subcomponent!": {
+          "$ref": "#/properties/maintainer/properties/subcomponent"
+        },
+        "subcomponent?": {
+          "$ref": "#/properties/maintainer/properties/subcomponent"
+        },
+        "subcomponent-": {}
+      },
+      "additionalProperties": false
+    },
+    "maintainer!": {
+      "$ref": "#/properties/maintainer"
+    },
+    "maintainer?": {
+      "$ref": "#/properties/maintainer"
+    },
+    "maintainer-": {},
+    "for_payload": {
+      "type": "boolean"
+    },
+    "for_payload!": {
+      "$ref": "#/properties/for_payload"
+    },
+    "for_payload?": {
+      "$ref": "#/properties/for_payload"
+    },
+    "for_payload-": {},
+    "for_release": {
+      "type": "boolean"
+    },
+    "for_release!": {
+      "$ref": "#/properties/for_release"
+    },
+    "for_release?": {
+      "$ref": "#/properties/for_release"
+    },
+    "for_release-": {},
+    "name_in_bundle": {
+      "type": "string",
+      "minLength": 1
+    },
+    "name_in_bundle!": {
+      "$ref": "#/properties/name_in_bundle"
+    },
+    "name_in_bundle?": {
+      "$ref": "#/properties/name_in_bundle"
+    },
+    "name_in_bundle-": {},
+    "is": {
+      "type": "object",
+      "properties": {
+        "nvr": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "nvr"
+      ],
+      "additionalProperties": false
+    },
+    "is!": {
+      "$ref": "#/properties/is"
+    },
+    "is?": {
+      "$ref": "#/properties/is"
+    },
+    "is-": {}
+  },
+  "additionalProperties": false
+}

--- a/validator/json_schemas/image_config.requires.schema.json
+++ b/validator/json_schemas/image_config.requires.schema.json
@@ -1,0 +1,238 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "image_config.requires.schema.json",
+    "properties": {
+      "content": {
+        "$ref": "image_content.requires.schema.json"
+      },
+      "odcs": {
+        "properties": {
+          "packages": {
+            "anyOf": [
+              {
+                "required": [
+                  "mode"
+                ]
+              },
+              {
+                "required": [
+                  "mode?"
+                ]
+              },
+              {
+                "required": [
+                  "mode!"
+                ]
+              }
+            ]
+          }
+        },
+        "anyOf": [
+          {
+            "required": [
+              "packages"
+            ]
+          },
+          {
+            "required": [
+              "packages?"
+            ]
+          },
+          {
+            "required": [
+              "packages!"
+            ]
+          }
+        ]
+      },
+      "scan_sources": {
+        "type": "object",
+        "properties": {
+          "extra_packages": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "name?"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "name!"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "tag"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "tag?"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "tag!"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "update-csv": {
+        "allOf": [
+          {
+            "anyOf": [
+              {
+                "required": [
+                  "manifests-dir"
+                ]
+              },
+              {
+                "required": [
+                  "manifests-dir?"
+                ]
+              },
+              {
+                "required": [
+                  "manifests-dir!"
+                ]
+              }
+            ]
+          },
+          {
+            "anyOf": [
+              {
+                "required": [
+                  "bundle-dir"
+                ]
+              },
+              {
+                "required": [
+                  "bundle-dir?"
+                ]
+              },
+              {
+                "required": [
+                  "bundle-dir!"
+                ]
+              }
+            ]
+          },
+          {
+            "anyOf": [
+              {
+                "required": [
+                  "registry"
+                ]
+              },
+              {
+                "required": [
+                  "registry?"
+                ]
+              },
+              {
+                "required": [
+                  "registry!"
+                ]
+              }
+            ]
+          },
+          {
+            "anyOf": [
+              {
+                "required": [
+                  "valid-subscription-label"
+                ]
+              },
+              {
+                "required": [
+                  "valid-subscription-label?"
+                ]
+              },
+              {
+                "required": [
+                  "valid-subscription-label!"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "maintainer": {
+        "anyOf": [
+          {
+            "required": [
+              "component"
+            ]
+          },
+          {
+            "required": [
+              "component?"
+            ]
+          },
+          {
+            "required": [
+              "component!"
+            ]
+          }
+        ]
+      }
+    },
+    "allOf": [
+      {
+        "anyOf": [
+          {
+            "required": [
+              "from"
+            ]
+          },
+          {
+            "required": [
+              "from?"
+            ]
+          },
+          {
+            "required": [
+              "from!"
+            ]
+          }
+        ]
+      },
+      {
+        "anyOf": [
+          {
+            "required": [
+              "name"
+            ]
+          },
+          {
+            "required": [
+              "name?"
+            ]
+          },
+          {
+            "required": [
+              "name!"
+            ]
+          }
+        ]
+      }
+    ]
+  }

--- a/validator/json_schemas/image_config.schema.json
+++ b/validator/json_schemas/image_config.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "image_config.schema.json",
+  "allOf": [
+    {
+      "$ref": "image_config.base.schema.json"
+    },
+    {
+      "$ref": "image_config.requires.schema.json"
+    }
+  ]
+}

--- a/validator/json_schemas/image_content.base.schema.json
+++ b/validator/json_schemas/image_content.base.schema.json
@@ -1,0 +1,374 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "image_content.base.schema.json",
+  "title": "Image Content",
+  "type": "object",
+  "properties": {
+    "source": {
+      "type": "object",
+      "properties": {
+        "alias": {
+          "type": "string",
+          "minLength": 1
+        },
+        "alias?": {
+          "$ref": "#/properties/source/properties/alias"
+        },
+        "alias!": {
+          "$ref": "#/properties/source/properties/alias"
+        },
+        "alias-": {},
+        "ci_alignment": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Whether to enable CI alignment. Default value: true",
+              "type": "boolean"
+            },
+            "enabled?": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/enabled"
+            },
+            "enabled!": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/enabled"
+            },
+            "enabled-": {},
+            "final_user": {
+              "description": "Parameter for the transform Dockerfile to set this user when complete",
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "final_user?": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/final_user"
+            },
+            "final_user!": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/final_user"
+            },
+            "final_user-": {},
+            "mirror": {
+              "description": "Whether to mirror this image for CI to use",
+              "type": "boolean"
+            },
+            "mirror?": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/mirror"
+            },
+            "mirror!": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/mirror"
+            },
+            "mirror-": {},
+            "streams_prs": {
+              "description": "Configuration for creating PRs to align upstream dockerfiles w/ ART",
+              "type": "object",
+              "properties": {
+                "ci_build_root": {
+                  "description": "Explicitly override the buildroot to be used for CI tests",
+                  "type": "object",
+                  "properties": {
+                    "stream": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "ci_build_root?": {
+                  "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs/properties/ci_build_root"
+                },
+                "ci_build_root!": {
+                  "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs/properties/ci_build_root"
+                },
+                "ci_build_root-": {},
+                "enabled": {
+                  "description": "Whether to create PRs to align upstream dockerfiles w/ ART. Default value: true",
+                  "type": "boolean"
+                },
+                "enabled?": {
+                  "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs/properties/enabled"
+                },
+                "enabled!": {
+                  "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs/properties/enabled"
+                },
+                "enabled-": {},
+                "auto_label": {
+                  "description": "automatically add labels to alignment PRs when created",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "auto_label?": {
+                  "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs/properties/auto_label"
+                },
+                "auto_label!": {
+                  "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs/properties/auto_label"
+                },
+                "auto_label-": {},
+                "from": {
+                  "description": "Explicitly override the FROMs to be used upstream",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "from?": {
+                  "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs/properties/from"
+                },
+                "from!": {
+                  "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs/properties/from"
+                },
+                "from-": {},
+                "merge_first": {
+                  "description": "`merge_first` means that child images will not get PRs opened until this image is aligned. This helps prevent images like OpenShift's base image from having 100s of PRs referencing its PR.",
+                  "type": "boolean"
+                },
+                "merge_first?": {
+                  "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs/properties/merge_first"
+                },
+                "merge_first!": {
+                  "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs/properties/merge_first"
+                },
+                "merge_first-": {},
+                "commit_prefix": {
+                  "description": "`commit_prefix` will add a prefix to the commit msg in ART alignment PRs",
+                  "type": "string"
+                },
+                "commit_prefix?": {
+                  "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs/properties/commit_prefix"
+                },
+                "commit_prefix!": {
+                  "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs/properties/commit_prefix"
+                },
+                "commit_prefix-": {}
+              },
+              "additionalProperties": false
+            },
+            "streams_prs?": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs"
+            },
+            "streams_prs!": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/streams_prs"
+            },
+            "streams_prs-": {},
+            "transform": {
+              "description": "When mirroring a base image for CI, we push and transform: run a build to add a layer (typically to add repos)",
+              "type": "string",
+              "minLength": 1
+            },
+            "transform?": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/transform"
+            },
+            "transform!": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/transform"
+            },
+            "transform-": {},
+            "upstream_image": {
+              "description": "When mirroring a base image for CI, we push and transform: transformed image landing point; streams_pr will use this as FROM",
+              "type": "string",
+              "minLength": 1
+            },
+            "upstream_image?": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/upstream_image"
+            },
+            "upstream_image!": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/upstream_image"
+            },
+            "upstream_image-": {},
+            "upstream_image_base": {
+              "description": "push the ART image here; transform is applied to it",
+              "type": "string",
+              "minLength": 1
+            },
+            "upstream_image_base?": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/upstream_image_base"
+            },
+            "upstream_image_base!": {
+              "$ref": "#/properties/source/properties/ci_alignment/properties/upstream_image_base"
+            },
+            "upstream_image_base-": {}
+          },
+          "additionalProperties": false
+        },
+        "ci_alignment?": {
+          "$ref": "#/properties/source/properties/ci_alignment"
+        },
+        "ci_alignment!": {
+          "$ref": "#/properties/source/properties/ci_alignment"
+        },
+        "ci_alignment-": {},
+        "dockerfile": {
+          "type": "string",
+          "minLength": 1
+        },
+        "dockerfile?": {
+          "$ref": "#/properties/source/properties/dockerfile"
+        },
+        "dockerfile!": {
+          "$ref": "#/properties/source/properties/dockerfile"
+        },
+        "dockerfile-": {},
+        "git": {
+          "type": "object",
+          "properties": {
+            "branch": {
+              "type": "object",
+              "properties": {
+                "target": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "target?": {
+                  "$ref": "#/properties/source/properties/git/properties/branch/properties/target"
+                },
+                "target!": {
+                  "$ref": "#/properties/source/properties/git/properties/branch/properties/target"
+                },
+                "target-": {},
+                "fallback": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "fallback?": {
+                  "$ref": "#/properties/source/properties/git/properties/branch/properties/fallback"
+                },
+                "fallback!": {
+                  "$ref": "#/properties/source/properties/git/properties/branch/properties/fallback"
+                },
+                "fallback-": {},
+                "stage": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "stage?": {
+                  "$ref": "#/properties/source/properties/git/properties/branch/properties/stage"
+                },
+                "stage!": {
+                  "$ref": "#/properties/source/properties/git/properties/branch/properties/stage"
+                },
+                "stage-": {}
+              },
+              "additionalProperties": false
+            },
+            "branch?": {
+              "$ref": "#/properties/source/properties/git/properties/branch"
+            },
+            "branch!": {
+              "$ref": "#/properties/source/properties/git/properties/branch"
+            },
+            "branch-": {},
+            "url": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "^((git@[\\w\\.]+))([\\w\\.@\\:/\\-~]+)(\\.git)(/)?$"
+            },
+            "url?": {
+              "$ref": "#/properties/source/properties/git/properties/url"
+            },
+            "url!": {
+              "$ref": "#/properties/source/properties/git/properties/url"
+            },
+            "url-": {},
+            "web": {
+              "type": "string",
+              "minLength": 1
+            },
+            "web?": {
+              "$ref": "#/properties/source/properties/git/properties/web"
+            },
+            "web!": {
+              "$ref": "#/properties/source/properties/git/properties/web"
+            },
+            "web-": {}
+          },
+          "additionalProperties": false
+        },
+        "git?": {
+          "$ref": "#/properties/source/properties/git"
+        },
+        "git!": {
+          "$ref": "#/properties/source/properties/git"
+        },
+        "git-": {},
+        "modifications": {
+          "type": "array",
+          "items": {
+            "$ref": "source_modification.schema.json"
+          }
+        },
+        "modifications?": {
+          "$ref": "#/properties/source/properties/modifications"
+        },
+        "modifications!": {
+          "$ref": "#/properties/source/properties/modifications"
+        },
+        "modifications-": {},
+        "path": {
+          "type": "string"
+        },
+        "path?": {
+          "$ref": "#/properties/source/properties/path"
+        },
+        "path!": {
+          "$ref": "#/properties/source/properties/path"
+        },
+        "path-": {},
+        "pkg_managers": {
+          "description": "List of package manager magics used in Cachito. See https://github.com/containerbuildsystem/cachito#package-managers",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "gomod",
+              "pip",
+              "npm",
+              "yarn",
+              "git-submodule"
+            ]
+          }
+        },
+        "pkg_managers?": {
+          "$ref": "#/properties/source/properties/pkg_managers"
+        },
+        "pkg_managers!": {
+          "$ref": "#/properties/source/properties/pkg_managers"
+        },
+        "pkg_managers-": {},
+        "artifacts": {
+          "type": "object",
+          "description": "Configuring external artfacts to fetch during OSBS build.",
+          "properties": {
+            "from_urls": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "artifacts?": {
+          "$ref": "#/properties/source/properties/artifacts"
+        },
+        "artifacts!": {
+          "$ref": "#/properties/source/properties/artifacts"
+        },
+        "artifacts-": {}
+      },
+      "additionalProperties": false
+    },
+    "source!": {
+      "$ref": "#/properties/source"
+    },
+    "source?": {
+      "$ref": "#/properties/source"
+    },
+    "source-": {}
+  },
+  "additionalProperties": false
+}

--- a/validator/json_schemas/image_content.requires.schema.json
+++ b/validator/json_schemas/image_content.requires.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "image_content.requires.schema.json",
+  "properties": {
+    "source": {
+      "properties": {
+        "ci_alignment": {
+          "properties": {
+            "streams_prs": {
+              "properties": {
+                "ci_build_root": {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "stream"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "stream?"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "stream!"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "git": {
+            "allOf": [
+              {
+                "anyOf": [
+                  {
+                    "required": [
+                      "branch"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "branch?"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "branch!"
+                    ]
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "required": [
+                      "url"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "url?"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "url!"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "git": {
+          "properties": {
+            "branch": {
+              "anyOf": [
+                {
+                  "required": [
+                    "target"
+                  ]
+                },
+                {
+                  "required": [
+                    "target?"
+                  ]
+                },
+                {
+                  "required": [
+                    "target!"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/validator/json_schemas/member_image.schema.json
+++ b/validator/json_schemas/member_image.schema.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "member_image.schema.json",
+  "title": "Assembly Member Image",
   "type": "object",
   "properties": {
     "distgit_key": {
@@ -11,73 +13,8 @@
       "minLength": 1
     },
     "metadata": {
-      "type": "object",
-      "properties": {
-        "content": {
-          "type": "object",
-          "$comment": "TODO: Validate image content config",
-          "additionalProperties": true
-        },
-        "content!": {
-          "$ref": "#/properties/metadata/properties/content"
-        },
-        "content?": {
-          "$ref": "#/properties/metadata/properties/content"
-        },
-        "content-": {},
-        "container_yaml": {
-          "type": "object"
-        },
-        "container_yaml!": {
-          "$ref": "#/properties/metadata/properties/container_yaml"
-        },
-        "container_yaml?": {
-          "$ref": "#/properties/metadata/properties/container_yaml"
-        },
-        "container_yaml-": {},
-        "cachito": {
-          "description": "Cachito integration configuration",
-          "$ref": "cachito.schema.json"
-        },
-        "cachito!": {
-          "$ref": "#/properties/metadata/properties/cachito"
-        },
-        "cachito?": {
-          "$ref": "#/properties/metadata/properties/cachito"
-        },
-        "cachito-": {},
-        "dependencies": {
-          "$ref": "assembly_dependencies.schema.json"
-        },
-        "dependencies!": {
-          "$ref": "#/properties/metadata/properties/dependencies"
-        },
-        "dependencies?": {
-          "$ref": "#/properties/metadata/properties/dependencies"
-        },
-        "dependencies-": {},
-        "is": {
-          "type": "object",
-          "properties": {
-            "nvr": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
-          "required": [
-            "nvr"
-          ],
-          "additionalProperties": false
-        },
-        "is!": {
-          "$ref": "#/properties/metadata/properties/is"
-        },
-        "is?": {
-          "$ref": "#/properties/metadata/properties/is"
-        },
-        "is-": {}
-      },
-      "additionalProperties": false
+      "description": "Image configuration",
+      "$ref": "image_config.base.schema.json"
     }
   },
   "required": [

--- a/validator/json_schemas/member_rpm.schema.json
+++ b/validator/json_schemas/member_rpm.schema.json
@@ -1,5 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "member_rpm.schema.json",
+    "title": "Assembly Member RPM",
     "type": "object",
     "properties": {
         "distgit_key": {

--- a/validator/json_schemas/release.schema.json
+++ b/validator/json_schemas/release.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "release.schema.json",
   "title": "Release",
   "description": "A release",
   "type": "object",

--- a/validator/json_schemas/releases.schema.json
+++ b/validator/json_schemas/releases.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "releases": "Releases",
+  "$id": "releases.schema.json",
+  "title": "Releases",
   "description": "Releases object contains information on every release that ART promotes as GA and every custom hotfix it delivers to customers.",
   "type": "object",
   "properties": {

--- a/validator/json_schemas/repos.schema.json
+++ b/validator/json_schemas/repos.schema.json
@@ -1,5 +1,7 @@
 {
     "type": "object",
+    "$id": "repos.schema.json",
+    "title": "Repositories",
     "$defs": {
         "repo": {
             "type": "object",

--- a/validator/json_schemas/rhcos.schema.json
+++ b/validator/json_schemas/rhcos.schema.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "rhcos.schema.json",
+  "title": "RHCOS",
   "description": "RHCOS images for the assembly.",
   "type": "object",
   "properties": {

--- a/validator/json_schemas/source_modification.schema.json
+++ b/validator/json_schemas/source_modification.schema.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "source_modification.schema.json",
+  "title": "Source Modification",
+  "type": "object",
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": [
+        "command",
+        "replace",
+        "add"
+      ]
+    },
+    "action?": {
+      "$ref": "#/properties/action"
+    },
+    "action!": {
+      "$ref": "#/properties/action"
+    },
+    "action-": {},
+    "command": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "update-console-sources",
+          "update-jenkins-label",
+          "upload-coreos-iso-to-lookaside-cache"
+        ]
+      }
+    },
+    "command?": {
+      "$ref": "#/properties/command"
+    },
+    "command!": {
+      "$ref": "#/properties/command"
+    },
+    "command-": {},
+    "match": {
+      "type": "string",
+      "minLength": 1
+    },
+    "match?": {
+      "$ref": "#/properties/match"
+    },
+    "match!": {
+      "$ref": "#/properties/match"
+    },
+    "match-": {},
+    "replacement": {
+      "type": "string"
+    },
+    "replacement?": {
+      "$ref": "#/properties/replacement"
+    },
+    "replacement!": {
+      "$ref": "#/properties/replacement"
+    },
+    "replacement-": {},
+    "source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source?": {
+      "$ref": "#/properties/source"
+    },
+    "source!": {
+      "$ref": "#/properties/source"
+    },
+    "source-": {},
+    "path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "path?": {
+      "$ref": "#/properties/path"
+    },
+    "path!": {
+      "$ref": "#/properties/path"
+    },
+    "path-": {},
+    "why": {
+      "type": "string",
+      "minLength": 1
+    },
+    "why?": {
+      "$ref": "#/properties/why"
+    },
+    "why!": {
+      "$ref": "#/properties/why"
+    },
+    "why-": {},
+    "overwriting": {
+      "type": "boolean"
+    },
+    "overwriting?": {
+      "$ref": "#/properties/overwriting"
+    },
+    "overwriting!": {
+      "$ref": "#/properties/overwriting"
+    },
+    "overwriting-": {}
+  },
+  "additionalProperties": false,
+  "anyOf": [
+    {
+      "required": [
+        "action"
+      ]
+    },
+    {
+      "required": [
+        "action!"
+      ]
+    },
+    {
+      "required": [
+        "action?"
+      ]
+    }
+  ]
+}

--- a/validator/json_schemas/streams.schema.json
+++ b/validator/json_schemas/streams.schema.json
@@ -1,5 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "streams.schema.json",
+    "title": "Streams",
     "$defs": {
         "stream": {
             "type": "object",

--- a/validator/schema/image_schema.py
+++ b/validator/schema/image_schema.py
@@ -1,223 +1,24 @@
-from validator import support
-from schema import Schema, Optional, And, Or, Regex, SchemaError
-from validator.schema.modification_schema import modification
+import json
 
-GIT_SSH_URL_REGEX = r'((git@[\w\.]+))([\w\.@\:/\-~]+)(\.git)(/)?'
-
-IMAGE_CONTENT_SCHEMA = {
-    'source': {
-        Optional('alias'): And(str, len),
-        Optional('ci_alignment'): {
-            # Default (Missing) == true.
-            Optional('enabled'): bool,
-            # parameter for the transform Dockerfile to set this user when complete
-            Optional('final_user'): Or(str, int),
-            # mirror this image for CI to use
-            Optional('mirror'): bool,
-            # configuration for creating PRs to align upstream dockerfiles w/ ART
-            Optional('streams_prs'): {
-                # Explicitly override the buildroot to be used for CI tests
-                Optional('ci_build_root'): {
-                    'stream': And(str, len),
-                },
-                # Default (Missing) == true.
-                Optional('enabled'): bool,
-                # automatically add labels to alignment PRs when created
-                Optional('auto_label'): [And(str, len)],
-                # Explicitly override the FROMs to be used upstream:
-                Optional('from'): [And(str, len)],
-                # merge_first means that child images will not get PRs opened
-                # until this image is aligned. This helps prevent images like
-                # openshift's base image from having 100s of PRs referencing
-                # its PR.
-                Optional('merge_first'): bool,
-                # commit_prefix will add a prefix to the commit msg in ART alignment PRs
-                Optional('commit_prefix'): str,
-            },
-            # when mirroring a base image for CI, we push and transform:
-            # run a build to add a layer (typically to add repos)
-            Optional('transform'): And(str, len),
-            # transformed image landing point; streams_pr will use this as FROM
-            Optional('upstream_image'): And(str, len),
-            # push the ART image here; transform is applied to it
-            Optional('upstream_image_base'): And(str, len),
-        },
-        Optional('dockerfile'): And(str, len),
-        Optional('git'): {
-            'branch': {
-                Optional('fallback'): And(str, len),
-                Optional('stage'): And(str, len),
-                'target': And(str, len),
-            },
-            'url': And(str, len, Regex(GIT_SSH_URL_REGEX)),
-            Optional('web'): And(str, len),
-        },
-        Optional('modifications'): [modification],
-        Optional('path'): str,
-        Optional(Or('pkg_managers', 'pkg_managers!')): [
-            And(str, len, lambda s: s in ('gomod', 'yarn', 'pip')),
-        ],
-    },
-}
-
-
-def image_schema(file):
-    valid_arches = [
-        'x86_64',
-        's390x',
-        'ppc64le',
-        'aarch64',
-    ]
-
-    valid_distgit_namespaces = [
-        'apbs',
-        'containers',
-        'rpms',
-    ]
-
-    valid_streams = support.get_valid_streams_for(file)
-    valid_member_references = support.get_valid_member_references_for(file)
-
-    valid_modes = [
-        'auto',
-        'disabled',
-        'wip',
-    ]
-
-    valid_odcs_modes = [
-        'auto',
-        'manual',
-    ]
-
-    return Schema({
-        Optional('additional_tags'): [
-            And(str, len),
-        ],
-        Optional('arches'): [Or(*valid_arches)],
-        Optional('base_only'): True,
-        Optional('container_yaml'): {
-            'go': {
-                'modules': [
-                    {
-                        'module': And(str, len),
-                        Optional('path'): str,
-                    },
-                ],
-            },
-        },
-        Optional('content'): IMAGE_CONTENT_SCHEMA,
-        Optional('dependents'): [
-            And(str, len)
-        ],
-        Optional('distgit'): {
-            Optional('namespace'): Or(*valid_distgit_namespaces),
-            Optional('component'): And(str, len),
-            Optional('bundle_component'): And(str, len),
-            Optional('branch'): And(str, len),
-        },
-        # When doozer injects USER 0 to do a yum update, this
-        # field instructs doozer to set this user afterwards
-        # in the final stage of the build.
-        Optional('final_stage_user'): Or(str, int),
-        Optional('enabled_repos'): [
-            And(str, len),
-        ],
-        Optional('non_shipping_repos'): [
-            And(str, len),
-        ],
-        Optional('non_shipping_rpms'): [
-            And(str, len),
-        ],
-        'from': {
-            Optional('builder'): [
-                {
-                    Optional('stream'): Or(*valid_streams),
-                    Optional('member'): Or(*valid_member_references),
-                    Optional('image'): And(str, len),
-                },
-            ],
-            Optional('image'): And(str, len),
-            Optional('stream'): Or(*valid_streams),
-            Optional('member'): Or(*valid_member_references),
-        },
-        Optional('labels'): {
-            Optional('summary'): And(str, len),
-            Optional('License'): And(str, len),
-            Optional('com.redhat.delivery.appregistry'): Or(bool, "true", "false"),
-            Optional('io.k8s.description'): And(str, len),
-            Optional('io.k8s.display-name'): And(str, len),
-            Optional('io.openshift.release.operator'): And(str, len),
-            Optional('io.openshift.tags'): And(str, len),
-            Optional('vendor'): And(str, len),
-        },
-        Optional('image_build_method'): And(str, len),
-        Optional('mode'): Or(*valid_modes),
-        'name': And(str, len),
-        Optional('odcs'): {
-            'packages': {
-                Optional('exclude'): [
-                    And(str, len),
-                ],
-                Optional('list'): [
-                    And(str, len),
-                ],
-                'mode': Or(*valid_odcs_modes),
-            },
-        },
-        Optional('no_oit_comments'): bool,
-        Optional('owners'): [
-            And(str, len),
-        ],
-        Optional('payload_name'): And(str, len),
-        Optional('push'): {
-            Optional('repos'): [
-                And(str, len),
-            ],
-            Optional('additional_tags'): [
-                And(str, len),
-            ],
-            Optional('late'): bool,
-        },
-        Optional('required'): bool,
-        Optional('scan_sources'): {
-            Optional('extra_packages'): [
-                {
-                    'name': And(str, len),
-                    'tag': And(str, len),
-                },
-            ],
-        },
-        Optional('update-csv'): {
-            'manifests-dir': And(str, len),
-            'bundle-dir': And(str, len),
-            'registry': And(str, len),
-            'valid-subscription-label': And(str, len),
-            Optional('channel'): And(str, len),
-            Optional('image-map'): dict,
-        },
-        Optional('wait_for'): And(str, len),
-        Optional('maintainer'): {
-            Optional('product'): And(str, len),
-            'component': And(str, len),
-            Optional('subcomponent'): And(str, len),
-        },
-        Optional('for_payload'): bool,
-        Optional('for_release'): bool,
-        Optional('name_in_bundle'): And(str, len),
-        Optional('cachito'): {
-            Optional('enabled'): bool,
-            Optional('flags'): [str],
-            Optional('packages'): {
-                Optional('gomod'): len,
-                Optional('yarn'): len,
-                Optional('pip'): len,
-            },
-        },
-    })
+import importlib_resources
+from jsonschema import RefResolver, ValidationError
+from jsonschema.validators import validator_for
 
 
 def validate(file, data):
+    # Load Json schemas
+    path = importlib_resources.files("validator") / "json_schemas"
+    schemas = {source.name: json.load(open(source)) for source in path.iterdir() if source.name.endswith(".json")}
+    schema_store = {schema.get("$id", filename): schema for filename, schema in schemas.items()}
+    schema = schema_store["image_config.schema.json"]
+    resolver = RefResolver.from_schema(schema, store=schema_store)
+    validator = validator_for(schema)(schema, resolver=resolver)
+
+    # Validate with JSON schemas
     try:
-        image_schema(file).validate(data)
-    except SchemaError as err:
-        return '{}'.format(err)
+        print(f"Validating {file}...")
+        validator.validate(data)
+        # TODO: Check if the base images referenced in `from` field exist
+    except ValidationError:
+        errors = validator.iter_errors(data)
+        return '\n\n'.join([str(e) for e in errors])


### PR DESCRIPTION
Adds JSON shecma files and use them validate image configs and image
config overrides in releases.yml.

Note in normal image config .yml files, some fields are required (e.g.
`name`). But in releases.yml, we only need to provide overrides. That
means all image config fields used in releases.yml are optional.
To accomplish this, I split the schema definition for an object into
`.base.schema.json` and `.requires.schema.json` so that we can load `.base.schema.json` to validate releases.yml
while loading both `.base.schema.json` and `.requires.schema.json` to
validate normal image configs.