### PR TITLE
[ART-4052] Add new config `update-csv > csv_namespace`

### DIFF
--- a/validator/schema/image_schema.py
+++ b/validator/schema/image_schema.py
@@ -193,6 +193,7 @@ def image_schema(file):
             'registry': And(str, len),
             Optional('channel'): And(str, len),
             Optional('image-map'): dict,
+            Optional('csv_namespace'): And(str, len),
         },
         Optional('wait_for'): And(str, len),
         Optional('maintainer'): {


### PR DESCRIPTION
Required by new TELCO images that make references to images outside `openshift/` namespace.