### PR TITLE
[ART-3883] rhcos.schema.json: assembly may also specify rhel-coreos-8

### DIFF
--- a/validator/json_schemas/rhcos.schema.json
+++ b/validator/json_schemas/rhcos.schema.json
@@ -43,6 +43,15 @@
     "machine-os-content?": {
       "$ref": "#/properties/machine-os-content"
     },
+    "rhel-coreos-8": {
+      "$ref": "#/properties/machine-os-content"
+    },
+    "rhel-coreos-8!": {
+      "$ref": "#/properties/machine-os-content"
+    },
+    "rhel-coreos-8?": {
+      "$ref": "#/properties/machine-os-content"
+    },
     "dependencies": {
       "$ref": "assembly_dependencies.schema.json"
     },


### PR DESCRIPTION
basically whenever RHCOS adds another container, we can just allow it here like this.

eventually we'll probably need to make `machine-os-content` not required and add other restrictions, but that's for later.